### PR TITLE
Actually remove scripts from project root

### DIFF
--- a/docker_build.bat
+++ b/docker_build.bat
@@ -1,1 +1,0 @@
-docker build -t opencircuits/opencircuits .

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,1 +1,0 @@
-docker build -t opencircuits/opencircuits .

--- a/docker_run.bat
+++ b/docker_run.bat
@@ -1,1 +1,0 @@
-docker run -p 8080:8080 --name opencircuits opencircuits/opencircuits

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,1 +1,0 @@
-docker run -p 8080:8080 --name opencircuits opencircuits/opencircuits


### PR DESCRIPTION
Previous PR conflict cause by not updating the branch, and not resolving those conflict correctly, leading to scripts staying in project root. Now they are deleted, as they are located in the `scripts/` folder.