### PR TITLE
dry out getImageName for flipflops

### DIFF
--- a/site/public/ts/models/ioobjects/flipflops/DFlipFlop.ts
+++ b/site/public/ts/models/ioobjects/flipflops/DFlipFlop.ts
@@ -23,10 +23,6 @@ export class DFlipFlop extends FlipFlop {
 		return "D Flip Flop";
 	}
 
-	public getImageName() {
-		return "flipflop.svg";
-	}
-
     public getXMLName(): string {
         return "dff";
     }

--- a/site/public/ts/models/ioobjects/flipflops/FlipFlop.ts
+++ b/site/public/ts/models/ioobjects/flipflops/FlipFlop.ts
@@ -29,4 +29,7 @@ export abstract class FlipFlop extends Component {
         this.setOutputPortCount(node.getIntAttribute("outputs"));
     }
 
+    public getImageName() {
+        return "flipflop.svg";
+    }
 }

--- a/site/public/ts/models/ioobjects/flipflops/FlipFlop.ts
+++ b/site/public/ts/models/ioobjects/flipflops/FlipFlop.ts
@@ -29,7 +29,7 @@ export abstract class FlipFlop extends Component {
         this.setOutputPortCount(node.getIntAttribute("outputs"));
     }
 
-    public getImageName() {
-        return "flipflop.svg";
-    }
+	public getImageName() {
+		return "flipflop.svg";
+	}
 }

--- a/site/public/ts/models/ioobjects/flipflops/JKFlipFlop.ts
+++ b/site/public/ts/models/ioobjects/flipflops/JKFlipFlop.ts
@@ -31,10 +31,6 @@ export class JKFlipFlop extends FlipFlop {
 		return "JK Flip Flop";
 	}
 
-	public getImageName() {
-		return "flipflop.svg";
-	}
-
     public getXMLName(): string {
         return "jkff";
     }

--- a/site/public/ts/models/ioobjects/flipflops/SRFlipFlop.ts
+++ b/site/public/ts/models/ioobjects/flipflops/SRFlipFlop.ts
@@ -31,10 +31,6 @@ export class SRFlipFlop extends FlipFlop {
 		return "SR Flip Flop";
 	}
 
-	public getImageName() {
-		return "flipflop.svg";
-	}
-
     public getXMLName(): string {
         return "srff";
     }

--- a/site/public/ts/models/ioobjects/flipflops/TFlipFlop.ts
+++ b/site/public/ts/models/ioobjects/flipflops/TFlipFlop.ts
@@ -23,10 +23,6 @@ export class TFlipFlop extends FlipFlop {
 		return "T Flip Flop";
 	}
 
-	public getImageName() {
-		return "flipflop.svg";
-	}
-
     public getXMLName(): string {
         return "tff";
     }


### PR DESCRIPTION
I moved the getImageName function from the flip flop children to the parent flip flop class so that it is less prone to error, more extendible and easier to add a unit test for