### PR TITLE
Fixed copying of PressableObjects

### DIFF
--- a/site/public/ts/models/ioobjects/PressableComponent.ts
+++ b/site/public/ts/models/ioobjects/PressableComponent.ts
@@ -71,6 +71,7 @@ export abstract class PressableComponent extends Component {
 	public copy(): PressableComponent {
 		let copy = <PressableComponent>super.copy();
 		copy.pressableBox = this.pressableBox.copy();
+		copy.pressableBox.setParent(copy.transform);
 		return copy;
 	}
 


### PR DESCRIPTION
There was a scary bug that failed to properly copy the PressableTransform

Fix #266 