### PR TITLE
Fixed double logging

### DIFF
--- a/site/go/main.go
+++ b/site/go/main.go
@@ -8,7 +8,6 @@ import (
 func main() {
 	router := gin.Default()
 
-	router.Use(gin.Logger())
 	router.Use(gin.Recovery())
 
 	web.RegisterPages(router)


### PR DESCRIPTION
Closes #327 

`gin.Logger()` is automatically included in `gin.Default()` now, so this line is no longer necessary and causes each request to be logged twice.