### PR TITLE
Added forced "Bundle.js" invalidation

### DIFF
--- a/site/go/web/handlers.go
+++ b/site/go/web/handlers.go
@@ -50,6 +50,6 @@ func IndexHandler(c *gin.Context) {
 
 func NoCacheHandler(path string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Redirect(http.StatusFound, path)
+		c.File(path)
 	}
 }

--- a/site/go/web/handlers.go
+++ b/site/go/web/handlers.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"time"
 )
 
 type Item struct {
@@ -43,5 +45,11 @@ func init() {
 }
 
 func IndexHandler(c *gin.Context) {
-	c.HTML(http.StatusOK, "index.tmpl", gin.H{"navConfig": navConfig, "l": false, "userId": ""})
+	c.HTML(http.StatusOK, "index.tmpl", gin.H{"navConfig": navConfig, "l": false, "user_id": "" , "timeNow": strconv.FormatInt(time.Now().Unix(), 10)})
+}
+
+func NoCacheHandler(path string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Redirect(http.StatusFound, path)
+	}
 }

--- a/site/go/web/handlers.go
+++ b/site/go/web/handlers.go
@@ -44,11 +44,25 @@ func init() {
 	}
 }
 
-func IndexHandler(c *gin.Context) {
-	c.HTML(http.StatusOK, "index.tmpl", gin.H{"navConfig": navConfig, "l": false, "user_id": "" , "timeNow": strconv.FormatInt(time.Now().Unix(), 10)})
+func getLastModifiedTime(path string) time.Time {
+	file, err := os.Stat(path)
+	if err != nil {
+		log.Printf("Invalid file path %s\n", path)
+		return time.Now()
+	}
+	return file.ModTime()
 }
 
-func NoCacheHandler(path string) gin.HandlerFunc {
+func getBustedName(path string) string {
+	return path + "?ver=" + strconv.FormatInt(getLastModifiedTime(path).Unix(), 10)
+}
+
+func indexHandler(c *gin.Context) {
+	c.HTML(http.StatusOK, "index.tmpl", gin.H{"navConfig": navConfig, "l": false, "user_id": "" ,
+		"bundleJs": getBustedName("./Bundle.js")})
+}
+
+func noCacheHandler(path string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.File(path)
 	}

--- a/site/go/web/routes.go
+++ b/site/go/web/routes.go
@@ -14,7 +14,7 @@ func RegisterPages(router* gin.Engine) {
 	router.StaticFile("/Bundle.js.map", "./Bundle.js.map")
 
 	// TODO: this is a hack to get bundles not not cache
-	router.GET("/bundle/:id", NoCacheHandler("/Bundle.js"))
+	router.GET("/bundle/:id", NoCacheHandler("./Bundle.js"))
 
 	router.GET("/", IndexHandler)
 }

--- a/site/go/web/routes.go
+++ b/site/go/web/routes.go
@@ -14,7 +14,7 @@ func RegisterPages(router* gin.Engine) {
 	router.StaticFile("/Bundle.js.map", "./Bundle.js.map")
 
 	// TODO: this is a hack to get bundles not not cache
-	router.GET("/bundle/:id", NoCacheHandler("./Bundle.js"))
+	router.GET("/Bundle.js?ver=:id", noCacheHandler("./Bundle.js"))
 
-	router.GET("/", IndexHandler)
+	router.GET("/", indexHandler)
 }

--- a/site/go/web/routes.go
+++ b/site/go/web/routes.go
@@ -13,5 +13,8 @@ func RegisterPages(router* gin.Engine) {
 	router.StaticFile("/Bundle.js", "./Bundle.js")
 	router.StaticFile("/Bundle.js.map", "./Bundle.js.map")
 
+	// TODO: this is a hack to get bundles not not cache
+	router.GET("/bundle/:id", NoCacheHandler("/Bundle.js"))
+
 	router.GET("/", IndexHandler)
 }

--- a/site/templates/index.tmpl
+++ b/site/templates/index.tmpl
@@ -173,7 +173,7 @@
     </main>
 </div>
 
-<script src="/bundle/{{.timeNow}}"></script>
+<script src="{{.bundleJs}}"></script>
 </body>
 
 </html>

--- a/site/templates/index.tmpl
+++ b/site/templates/index.tmpl
@@ -173,7 +173,7 @@
     </main>
 </div>
 
-<script src="Bundle.js"></script>
+<script src="/bundle/{{.timeNow}}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Since there is no cache busting scheme in place yet, this is a quick fix to let developers use a normal "reload" to update their front-end code.

Fix #332 