### PR TITLE
Copy fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ site/data/config.txt
 site/public/js/combined-min.js
 tests/index.js
 package-lock.json
+yarn.lock
 
 # IntelliJ
 .idea/

--- a/app/digital/ts/models/ioobjects/PressableComponent.ts
+++ b/app/digital/ts/models/ioobjects/PressableComponent.ts
@@ -74,6 +74,7 @@ export abstract class PressableComponent extends Component {
         const copy = <PressableComponent>super.copy();
         copy.pressableBox = this.pressableBox.copy();
         copy.pressableBox.setParent(copy.transform);
+        copy.activate(this.isOn());
         return copy;
     }
 

--- a/app/digital/ts/models/ioobjects/inputs/ConstantHigh.ts
+++ b/app/digital/ts/models/ioobjects/inputs/ConstantHigh.ts
@@ -20,7 +20,7 @@ export class ConstantHigh extends Component {
 
     // @Override
     public copy(): Component {
-        let c = super.copy();
+        const c = super.copy();
         c.activate(true);
         return c;
     }

--- a/app/digital/ts/models/ioobjects/inputs/ConstantHigh.ts
+++ b/app/digital/ts/models/ioobjects/inputs/ConstantHigh.ts
@@ -18,6 +18,13 @@ export class ConstantHigh extends Component {
         return "consthigh";
     }
 
+    // @Override
+    public copy(): Component {
+        let c = super.copy();
+        c.activate(true);
+        return c;
+    }
+
     public getImageName(): string {
         return "constHigh.svg";
     }


### PR DESCRIPTION
Closes #402, and analogous bugs for `ConstantHigh` and other `PressableComponents`. Also adds yarn.lock to the gitignore.