### PR TITLE
Mux Output

### DIFF
--- a/app/core/ts/models/ports/PortSets.ts
+++ b/app/core/ts/models/ports/PortSets.ts
@@ -57,6 +57,10 @@ export class PortSet<T extends Port> {
         this.positioner.updatePortPositions(this.currentPorts);
     }
 
+    /**
+     * Updates the positions of the ports in the set. Allows for
+     * position updating even when the size does not change
+     */
     public updatePortPositions(): void {
         this.positioner.updatePortPositions(this.currentPorts);
     }

--- a/app/core/ts/models/ports/PortSets.ts
+++ b/app/core/ts/models/ports/PortSets.ts
@@ -57,6 +57,10 @@ export class PortSet<T extends Port> {
         this.positioner.updatePortPositions(this.currentPorts);
     }
 
+    public updatePortPositions(): void {
+        this.positioner.updatePortPositions(this.currentPorts);
+    }
+
     public get(i: number): T {
         return this.currentPorts[i];
     }

--- a/app/digital/ts/models/ioobjects/other/Demultiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Demultiplexer.ts
@@ -1,7 +1,7 @@
 import {ClampedValue} from "math/ClampedValue";
 
 import {OutputPort} from "../../ports/OutputPort";
-import {MuxPositioner} from "../../ports/positioners/MuxPositioners";
+import {MuxPositioner, DemuxInputPositioner} from "../../ports/positioners/MuxPositioners";
 
 import {Mux} from "./Mux";
 
@@ -9,7 +9,7 @@ export class Demultiplexer extends Mux {
 
     public constructor() {
         super(new ClampedValue(1), new ClampedValue(4, 2, Math.pow(2,8)),
-              undefined, new MuxPositioner<OutputPort>());
+              new DemuxInputPositioner(), new MuxPositioner<OutputPort>());
     }
 
     public activate(): void {
@@ -26,6 +26,8 @@ export class Demultiplexer extends Mux {
     public setSelectPortCount(val: number): void {
         super.setSelectPortCount(val);
         super.setOutputPortCount(Math.pow(2, val));
+        // update the input port to align with the left edge of the DeMux
+        this.inputs.updatePortPositions();
     }
 
     public getDisplayName(): string {

--- a/app/digital/ts/models/ioobjects/other/Demultiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Demultiplexer.ts
@@ -1,7 +1,7 @@
 import {ClampedValue} from "math/ClampedValue";
 
 import {OutputPort} from "../../ports/OutputPort";
-import {MuxPositioner, DemuxInputPositioner} from "../../ports/positioners/MuxPositioners";
+import {MuxPositioner, MuxSinglePortPositioner} from "../../ports/positioners/MuxPositioners";
 
 import {Mux} from "./Mux";
 
@@ -9,7 +9,7 @@ export class Demultiplexer extends Mux {
 
     public constructor() {
         super(new ClampedValue(1), new ClampedValue(4, 2, Math.pow(2,8)),
-              new DemuxInputPositioner(), new MuxPositioner<OutputPort>());
+              new MuxSinglePortPositioner(), new MuxPositioner<OutputPort>());
     }
 
     public activate(): void {

--- a/app/digital/ts/models/ioobjects/other/Demultiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Demultiplexer.ts
@@ -1,7 +1,8 @@
 import {ClampedValue} from "math/ClampedValue";
 
 import {OutputPort} from "../../ports/OutputPort";
-import {MuxPositioner, MuxSinglePortPositioner} from "../../ports/positioners/MuxPositioners";
+import {MuxPositioner,
+        MuxSinglePortPositioner} from "../../ports/positioners/MuxPositioners";
 
 import {Mux} from "./Mux";
 

--- a/app/digital/ts/models/ioobjects/other/Multiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Multiplexer.ts
@@ -5,7 +5,6 @@ import {MuxPositioner, MuxSinglePortPositioner} from "../../ports/positioners/Mu
 
 import {Mux} from "./Mux";
 
-
 export class Multiplexer extends Mux {
 
     public constructor() {

--- a/app/digital/ts/models/ioobjects/other/Multiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Multiplexer.ts
@@ -27,10 +27,8 @@ export class Multiplexer extends Mux {
     public setSelectPortCount(val: number): void {
         super.setSelectPortCount(val);
         super.setInputPortCount(Math.pow(2, val));
-        //do this next line in another way, idiot
-        //(new MuxOutputPositioner).updatePortPositions(this.outputs)
+        // update the output ports to align with the right edge of the Mux
         this.outputs.updatePortPositions();
-        //setPortCount(this.numOutputs())
     }
 
     public getDisplayName(): string {

--- a/app/digital/ts/models/ioobjects/other/Multiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Multiplexer.ts
@@ -26,6 +26,8 @@ export class Multiplexer extends Mux {
     public setSelectPortCount(val: number): void {
         super.setSelectPortCount(val);
         super.setInputPortCount(Math.pow(2, val));
+        //do this next line in another way, idiot
+        this.outputs.setPortCount(this.numOutputs())
     }
 
     public getDisplayName(): string {

--- a/app/digital/ts/models/ioobjects/other/Multiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Multiplexer.ts
@@ -29,7 +29,8 @@ export class Multiplexer extends Mux {
         super.setInputPortCount(Math.pow(2, val));
         //do this next line in another way, idiot
         //(new MuxOutputPositioner).updatePortPositions(this.outputs)
-        //this.outputs.setPortCount(this.numOutputs())
+        this.outputs.updatePortPositions();
+        //setPortCount(this.numOutputs())
     }
 
     public getDisplayName(): string {

--- a/app/digital/ts/models/ioobjects/other/Multiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Multiplexer.ts
@@ -1,7 +1,8 @@
 import {ClampedValue} from "math/ClampedValue";
 
 import {InputPort} from "../../ports/InputPort";
-import {MuxPositioner, MuxSinglePortPositioner} from "../../ports/positioners/MuxPositioners";
+import {MuxPositioner,
+        MuxSinglePortPositioner} from "../../ports/positioners/MuxPositioners";
 
 import {Mux} from "./Mux";
 

--- a/app/digital/ts/models/ioobjects/other/Multiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Multiplexer.ts
@@ -1,7 +1,7 @@
 import {ClampedValue} from "math/ClampedValue";
 
 import {InputPort} from "../../ports/InputPort";
-import {MuxPositioner, MuxOutputPositioner} from "../../ports/positioners/MuxPositioners";
+import {MuxPositioner, MuxSinglePortPositioner} from "../../ports/positioners/MuxPositioners";
 
 import {Mux} from "./Mux";
 
@@ -10,7 +10,7 @@ export class Multiplexer extends Mux {
 
     public constructor() {
         super(new ClampedValue(4, 2, Math.pow(2,8)), new ClampedValue(1),
-              new MuxPositioner<InputPort>(), new MuxOutputPositioner);
+              new MuxPositioner<InputPort>(), new MuxSinglePortPositioner());
     }
 
     /**
@@ -27,7 +27,7 @@ export class Multiplexer extends Mux {
     public setSelectPortCount(val: number): void {
         super.setSelectPortCount(val);
         super.setInputPortCount(Math.pow(2, val));
-        // update the output ports to align with the right edge of the Mux
+        // update the output port to align with the right edge of the Mux
         this.outputs.updatePortPositions();
     }
 

--- a/app/digital/ts/models/ioobjects/other/Multiplexer.ts
+++ b/app/digital/ts/models/ioobjects/other/Multiplexer.ts
@@ -1,15 +1,16 @@
 import {ClampedValue} from "math/ClampedValue";
 
 import {InputPort} from "../../ports/InputPort";
-import {MuxPositioner} from "../../ports/positioners/MuxPositioners";
+import {MuxPositioner, MuxOutputPositioner} from "../../ports/positioners/MuxPositioners";
 
 import {Mux} from "./Mux";
+
 
 export class Multiplexer extends Mux {
 
     public constructor() {
         super(new ClampedValue(4, 2, Math.pow(2,8)), new ClampedValue(1),
-              new MuxPositioner<InputPort>());
+              new MuxPositioner<InputPort>(), new MuxOutputPositioner);
     }
 
     /**
@@ -27,7 +28,8 @@ export class Multiplexer extends Mux {
         super.setSelectPortCount(val);
         super.setInputPortCount(Math.pow(2, val));
         //do this next line in another way, idiot
-        this.outputs.setPortCount(this.numOutputs())
+        //(new MuxOutputPositioner).updatePortPositions(this.outputs)
+        //this.outputs.setPortCount(this.numOutputs())
     }
 
     public getDisplayName(): string {

--- a/app/digital/ts/models/ioobjects/other/Mux.ts
+++ b/app/digital/ts/models/ioobjects/other/Mux.ts
@@ -20,7 +20,7 @@ export abstract class Mux extends DigitalComponent {
         super(inputPortCount, outputPortCount, V(DEFAULT_SIZE+10, 2*DEFAULT_SIZE), inputPositioner, outputPositioner);
 
         this.selects = new PortSet<InputPort>(this, new ClampedValue(2, 1, 8), new MuxSelectPositioner(), InputPort);
-        
+
         this.setSelectPortCount(2);
     }
 
@@ -29,7 +29,7 @@ export abstract class Mux extends DigitalComponent {
         const width = Math.max(DEFAULT_SIZE/2*(val-1), DEFAULT_SIZE);
         const height = DEFAULT_SIZE/2*Math.pow(2, val);
         this.transform.setSize(V(width+10, height));
-        
+
         this.selects.setPortCount(val);
     }
 

--- a/app/digital/ts/models/ioobjects/other/Mux.ts
+++ b/app/digital/ts/models/ioobjects/other/Mux.ts
@@ -20,9 +20,6 @@ export abstract class Mux extends DigitalComponent {
         super(inputPortCount, outputPortCount, V(DEFAULT_SIZE+10, 2*DEFAULT_SIZE), inputPositioner, outputPositioner);
 
         this.selects = new PortSet<InputPort>(this, new ClampedValue(2, 1, 8), new MuxSelectPositioner(), InputPort);
-        // is this next line the best way to declare this?
-        //this.outputs = new PortSet<OutputPort>(this, new ClampedValue(1, 1, Math.pow(2, 8)), new MuxOutputPositioner(), OutputPort)
-        
         this.setSelectPortCount(2);
     }
 

--- a/app/digital/ts/models/ioobjects/other/Mux.ts
+++ b/app/digital/ts/models/ioobjects/other/Mux.ts
@@ -20,6 +20,7 @@ export abstract class Mux extends DigitalComponent {
         super(inputPortCount, outputPortCount, V(DEFAULT_SIZE+10, 2*DEFAULT_SIZE), inputPositioner, outputPositioner);
 
         this.selects = new PortSet<InputPort>(this, new ClampedValue(2, 1, 8), new MuxSelectPositioner(), InputPort);
+        
         this.setSelectPortCount(2);
     }
 
@@ -28,6 +29,7 @@ export abstract class Mux extends DigitalComponent {
         const width = Math.max(DEFAULT_SIZE/2*(val-1), DEFAULT_SIZE);
         const height = DEFAULT_SIZE/2*Math.pow(2, val);
         this.transform.setSize(V(width+10, height));
+        
         this.selects.setPortCount(val);
     }
 

--- a/app/digital/ts/models/ioobjects/other/Mux.ts
+++ b/app/digital/ts/models/ioobjects/other/Mux.ts
@@ -7,7 +7,7 @@ import {Positioner} from "core/models/ports/positioners/Positioner";
 
 import {InputPort} from "digital/models/ports/InputPort";
 import {OutputPort} from "digital/models/ports/OutputPort";
-import {MuxSelectPositioner} from "digital/models/ports/positioners/MuxPositioners";
+import {MuxSelectPositioner, MuxOutputPositioner} from "digital/models/ports/positioners/MuxPositioners";
 
 import {DigitalComponent} from "digital/models/DigitalComponent";
 import {PortSet} from "core/models/ports/PortSets";
@@ -20,7 +20,9 @@ export abstract class Mux extends DigitalComponent {
         super(inputPortCount, outputPortCount, V(DEFAULT_SIZE+10, 2*DEFAULT_SIZE), inputPositioner, outputPositioner);
 
         this.selects = new PortSet<InputPort>(this, new ClampedValue(2, 1, 8), new MuxSelectPositioner(), InputPort);
-
+        // is this next line the best way to declare this?
+        //this.outputs = new PortSet<OutputPort>(this, new ClampedValue(1, 1, Math.pow(2, 8)), new MuxOutputPositioner(), OutputPort)
+        
         this.setSelectPortCount(2);
     }
 
@@ -29,7 +31,6 @@ export abstract class Mux extends DigitalComponent {
         const width = Math.max(DEFAULT_SIZE/2*(val-1), DEFAULT_SIZE);
         const height = DEFAULT_SIZE/2*Math.pow(2, val);
         this.transform.setSize(V(width+10, height));
-
         this.selects.setPortCount(val);
     }
 

--- a/app/digital/ts/models/ioobjects/other/Mux.ts
+++ b/app/digital/ts/models/ioobjects/other/Mux.ts
@@ -7,7 +7,7 @@ import {Positioner} from "core/models/ports/positioners/Positioner";
 
 import {InputPort} from "digital/models/ports/InputPort";
 import {OutputPort} from "digital/models/ports/OutputPort";
-import {MuxSelectPositioner, MuxOutputPositioner} from "digital/models/ports/positioners/MuxPositioners";
+import {MuxSelectPositioner} from "digital/models/ports/positioners/MuxPositioners";
 
 import {DigitalComponent} from "digital/models/DigitalComponent";
 import {PortSet} from "core/models/ports/PortSets";

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -77,11 +77,11 @@ export class DemuxInputPositioner extends Positioner<InputPort> {
      */
     public updatePortPositions(ports: Array<InputPort>): void {
         ports.forEach((port, i) => {
-            //const xPos = port.getParent().getSize().x;
-            //let l = port.getParent().getSize().x - 10*port.getParent().getInputPortCount().getValue();
-            let l = port.getParent().getSize().x;
-            //port.setOriginPos()
-            //port.setTargetPos(V())
+            // Set the origin position to the left edge of the Demux
+            let width = port.getParent().getSize().x;
+            port.setOriginPos(V(-width/2, 0));
+            // Set the target position such that the port wire length is consistent
+            port.setTargetPos(V(-width/2 - IO_PORT_LENGTH + DEFAULT_SIZE/2, 0));
         });       
     }
 }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -1,11 +1,10 @@
 import {DEFAULT_SIZE,
         IO_PORT_LENGTH} from "core/utils/Constants";
 
-import {V, Vector} from "Vector";
+import {V} from "Vector";
 
 import {Port} from "core/models/ports/Port";
 import {InputPort} from "../InputPort";
-import {OutputPort} from "../OutputPort";
 
 import {Positioner} from "core/models/ports/positioners/Positioner";
 
@@ -31,7 +30,7 @@ export class MuxPositioner<T extends Port> extends Positioner<T> {
 export class MuxSelectPositioner extends Positioner<InputPort> {
 
     /**
-     * Port positiong for Multiplexer/Demultiplexer select lines
+     * Port positioning for Multiplexer/Demultiplexer select lines
      *
      * @param arr The array of input ports
      */
@@ -52,36 +51,17 @@ export class MuxSelectPositioner extends Positioner<InputPort> {
 
 }
 
-export class MuxOutputPositioner extends Positioner<OutputPort> {
+export class MuxSinglePortPositioner<T extends Port> extends Positioner<T> {
     /**
-     * Port positioning for Multiplexer output ports
+     * Port positioning for Multiplexer output port and Demultiplexer input port
      * 
-     * @paramm arr The array of output ports
+     * @param ports the array of ports to be positioned
      */
-    public updatePortPositions(ports: Array<OutputPort>): void {
-        ports.forEach((port) => {
-            // Set the origin position to the right edge of the Mux
-            let width = port.getParent().getSize().x;
-            port.setOriginPos(V(width/2, 0));
-            // Set the target position such that the port wire length is consistent
-            port.setTargetPos(V(width/2 + IO_PORT_LENGTH - DEFAULT_SIZE/2, 0));
-        });
-    }
-}
-
-export class DemuxInputPositioner extends Positioner<InputPort> {
-    /**
-     * Port positioning for Demultiplexer input port
-     * 
-     * @paramm arr the array of input ports
-     */
-    public updatePortPositions(ports: Array<InputPort>): void {
+    public updatePortPositions(ports: Array<T>): void {
         ports.forEach((port, i) => {
-            // Set the origin position to the left edge of the Demux
-            let width = port.getParent().getSize().x;
-            port.setOriginPos(V(-width/2, 0));
-            // Set the target position such that the port wire length is consistent
-            port.setTargetPos(V(-width/2 - IO_PORT_LENGTH + DEFAULT_SIZE/2, 0));
-        });       
+            const width = port.getParent().getSize().x;
+            port.setOriginPos(V(port.getInitialDir().scale(width/2)))
+            port.setTargetPos(V(port.getInitialDir().scale(IO_PORT_LENGTH + (width - DEFAULT_SIZE)/2)));
+        });
     }
 }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -1,7 +1,7 @@
 import {DEFAULT_SIZE,
         IO_PORT_LENGTH} from "core/utils/Constants";
 
-import {V} from "Vector";
+import {V, Vector} from "Vector";
 
 import {Port} from "core/models/ports/Port";
 import {InputPort} from "../InputPort";
@@ -65,13 +65,26 @@ export class MuxOutputPositioner extends Positioner<OutputPort> {
                 TODO: get the normal x value then add, not current x value
                       change the origin position based on IO_PORT_LENGTH so its not too long
             */
-
+/*
+            // calculate the number of select ports (cannot be )
+            let sel = Math.log2(port.getParent().getInputPortCount().getValue());
             // set the target position of the port
-            let l = port.getParent().getSize().x; //+ DEFAULT_SIZE;
-            
-            port.setTargetPos(V(l, port.getTargetPos().y));
+            //let l = port.getParent().getSize().x; //+ DEFAULT_SIZE;
+            //let l = port.getParent().getPos().x// + port.getParent().getSize().x;
+            //let l = port.getParent().getTransform().getBottomRight().x
+            //let l = port.getParent().getMaxPos().x;
+
+            let l = Vector.max(...port.getParent().getTransform().getCorners());
+
+            port.setOriginPos(V(l.x, port.getParent().getSize().y));
             // set the origin position to be a DEFAULT_SIZE away from the target position
-            port.setOriginPos(port.getTargetPos().sub(V(DEFAULT_SIZE, 0)))
+            port.setTargetPos(port.getOriginPos().add(V(IO_PORT_LENGTH, 0)))
+            */
+            port.setTargetPos(port.getParent().getSize())
+            let width = port.getParent().getSize().x;
+            //port.setOriginPos(port.getTargetPos().sub(V(IO_PORT_LENGTH, 0)));
+            port.setOriginPos(V(width/2, 0));
+            port.setTargetPos(V(width/2 + IO_PORT_LENGTH - DEFAULT_SIZE/2, 0));
             //let l = 10*Math.max(port.getParent().getInputPortCount().getValue(), port.getParent().getOutputPortCount().getValue());
             //port.setTargetPos(port.getTargetPos().add(V(l, l)))
         });
@@ -87,7 +100,9 @@ export class DemuxInputPositioner extends Positioner<InputPort> {
     public updatePortPositions(ports: Array<InputPort>): void {
         ports.forEach((port, i) => {
             //const xPos = port.getParent().getSize().x;
-            let l = port.getParent().getSize().x - 10*port.getParent().getInputPortCount().getValue();
+            //let l = port.getParent().getSize().x - 10*port.getParent().getInputPortCount().getValue();
+            let l = port.getParent().getSize().x;
+            //port.setOriginPos()
             //port.setTargetPos(V())
         });       
     }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -59,34 +59,12 @@ export class MuxOutputPositioner extends Positioner<OutputPort> {
      * @paramm arr The array of output ports
      */
     public updatePortPositions(ports: Array<OutputPort>): void {
-        ports.forEach((port, i) => {
-            const height = port.getParent().getSize().y;
-            /*
-                TODO: get the normal x value then add, not current x value
-                      change the origin position based on IO_PORT_LENGTH so its not too long
-            */
-/*
-            // calculate the number of select ports (cannot be )
-            let sel = Math.log2(port.getParent().getInputPortCount().getValue());
-            // set the target position of the port
-            //let l = port.getParent().getSize().x; //+ DEFAULT_SIZE;
-            //let l = port.getParent().getPos().x// + port.getParent().getSize().x;
-            //let l = port.getParent().getTransform().getBottomRight().x
-            //let l = port.getParent().getMaxPos().x;
-
-            let l = Vector.max(...port.getParent().getTransform().getCorners());
-
-            port.setOriginPos(V(l.x, port.getParent().getSize().y));
-            // set the origin position to be a DEFAULT_SIZE away from the target position
-            port.setTargetPos(port.getOriginPos().add(V(IO_PORT_LENGTH, 0)))
-            */
-            port.setTargetPos(port.getParent().getSize())
+        ports.forEach((port) => {
+            // Set the origin position to the right edge of the Mux
             let width = port.getParent().getSize().x;
-            //port.setOriginPos(port.getTargetPos().sub(V(IO_PORT_LENGTH, 0)));
             port.setOriginPos(V(width/2, 0));
+            // Set the target position such that the port wire length is consistent
             port.setTargetPos(V(width/2 + IO_PORT_LENGTH - DEFAULT_SIZE/2, 0));
-            //let l = 10*Math.max(port.getParent().getInputPortCount().getValue(), port.getParent().getOutputPortCount().getValue());
-            //port.setTargetPos(port.getTargetPos().add(V(l, l)))
         });
     }
 }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -61,23 +61,19 @@ export class MuxOutputPositioner extends Positioner<OutputPort> {
     public updatePortPositions(ports: Array<OutputPort>): void {
         ports.forEach((port, i) => {
             const height = port.getParent().getSize().y;
-
-            // Calculate x position of port
-
-            // Calculate y position of the port
-            //let y = -height/2*(i - ports.length/2 + 0.5)
-
-            //if(port.getParent().getInputPortCount().getValue() <= Math.pow(2,2)){
-            let l = port.getParent().getSize().x + 10*port.getParent().getInputPortCount().getValue();
-            
-
-
             /*
                 TODO: get the normal x value then add, not current x value
                       change the origin position based on IO_PORT_LENGTH so its not too long
             */
+
+            // set the target position of the port
+            let l = port.getParent().getSize().x; //+ DEFAULT_SIZE;
+            
             port.setTargetPos(V(l, port.getTargetPos().y));
-            //port.setOriginPos(V())
+            // set the origin position to be a DEFAULT_SIZE away from the target position
+            port.setOriginPos(port.getTargetPos().sub(V(DEFAULT_SIZE, 0)))
+            //let l = 10*Math.max(port.getParent().getInputPortCount().getValue(), port.getParent().getOutputPortCount().getValue());
+            //port.setTargetPos(port.getTargetPos().add(V(l, l)))
         });
     }
 }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -5,8 +5,10 @@ import {V} from "Vector";
 
 import {Port} from "core/models/ports/Port";
 import {InputPort} from "../InputPort";
+import {OutputPort} from "../OutputPort";
 
 import {Positioner} from "core/models/ports/positioners/Positioner";
+
 
 export class MuxPositioner<T extends Port> extends Positioner<T> {
 
@@ -48,4 +50,33 @@ export class MuxSelectPositioner extends Positioner<InputPort> {
         });
     }
 
+}
+
+export class MuxOutputPositioner extends Positioner<OutputPort> {
+    /**
+     * Port positioning for Multiplexer output ports
+     * 
+     * @paramm arr The array of output ports
+     */
+    public updatePortPositions(ports: Array<OutputPort>): void {
+        ports.forEach((port, i) => {
+            const height = port.getParent().getSize().y;
+
+            // Calculate x position of port
+
+            // Calculate y position of the port
+            //let y = -height/2*(i - ports.length/2 + 0.5)
+
+            //if(port.getParent().getInputPortCount().getValue() <= Math.pow(2,2)){
+            let l = port.getParent().getSize().x + 10*port.getParent().getInputPortCount().getValue();
+            
+
+
+            /*
+                TODO: get the normal x value then add, not current x value
+                      change the origin position based on IO_PORT_LENGTH so its not too long
+            */
+            port.setTargetPos(V(l, port.getTargetPos().y));
+        });
+    }
 }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -8,7 +8,6 @@ import {InputPort} from "../InputPort";
 
 import {Positioner} from "core/models/ports/positioners/Positioner";
 
-
 export class MuxPositioner<T extends Port> extends Positioner<T> {
 
     public updatePortPositions(ports: Array<T>): void {
@@ -60,8 +59,10 @@ export class MuxSinglePortPositioner<T extends Port> extends Positioner<T> {
     public updatePortPositions(ports: Array<T>): void {
         ports.forEach((port, i) => {
             const width = port.getParent().getSize().x;
+            // Set the origin of the port to the left side of the Mux
             port.setOriginPos(V(port.getInitialDir().scale(width/2)))
-            port.setTargetPos(V(port.getInitialDir().scale(IO_PORT_LENGTH + (width - DEFAULT_SIZE)/2)));
+            // Set the target position such that the port wire length is consistent
+            port.setTargetPos(V(port.getInitialDir().scale(IO_PORT_LENGTH+(width-DEFAULT_SIZE)/2)));
         });
     }
 }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -51,6 +51,7 @@ export class MuxSelectPositioner extends Positioner<InputPort> {
 }
 
 export class MuxSinglePortPositioner<T extends Port> extends Positioner<T> {
+    
     /**
      * Port positioning for Multiplexer output port and Demultiplexer input port
      * 
@@ -65,4 +66,5 @@ export class MuxSinglePortPositioner<T extends Port> extends Positioner<T> {
             port.setTargetPos(V(port.getInitialDir().scale(IO_PORT_LENGTH+(width-DEFAULT_SIZE)/2)));
         });
     }
+    
 }

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -57,7 +57,7 @@ export class MuxSinglePortPositioner<T extends Port> extends Positioner<T> {
      * @param ports the array of ports to be positioned
      */
     public updatePortPositions(ports: Array<T>): void {
-        ports.forEach((port, i) => {
+        ports.forEach((port) => {
             const width = port.getParent().getSize().x;
             // Set the origin of the port to the left side of the Mux
             port.setOriginPos(V(port.getInitialDir().scale(width/2)))

--- a/app/digital/ts/models/ports/positioners/MuxPositioners.ts
+++ b/app/digital/ts/models/ports/positioners/MuxPositioners.ts
@@ -77,6 +77,22 @@ export class MuxOutputPositioner extends Positioner<OutputPort> {
                       change the origin position based on IO_PORT_LENGTH so its not too long
             */
             port.setTargetPos(V(l, port.getTargetPos().y));
+            //port.setOriginPos(V())
         });
+    }
+}
+
+export class DemuxInputPositioner extends Positioner<InputPort> {
+    /**
+     * Port positioning for Demultiplexer input port
+     * 
+     * @paramm arr the array of input ports
+     */
+    public updatePortPositions(ports: Array<InputPort>): void {
+        ports.forEach((port, i) => {
+            //const xPos = port.getParent().getSize().x;
+            let l = port.getParent().getSize().x - 10*port.getParent().getInputPortCount().getValue();
+            //port.setTargetPos(V())
+        });       
     }
 }


### PR DESCRIPTION
Fixed the issue of the Mux Output and Demux Input ports not moving when the object is resized, causing them to get lost under the render of the object. Created the MuxSinglePortPositioner class to position the output port of the Multiplexer and the input port of the Demultiplexer properly. Also created a public updatePortPositions function under the PortSet class, to allow updating port positions using the positioner even when the size of the PortSet does not change (which it does not for the Mux/Demux objects).