### PR TITLE
Added double clicking for wire

### DIFF
--- a/app/core/ts/tools/SelectionTool.ts
+++ b/app/core/ts/tools/SelectionTool.ts
@@ -12,6 +12,7 @@ import {Wire} from "core/models/Wire";
 import {Component} from "core/models/Component";
 import {Node, isNode} from "core/models/Node";
 import {CircuitDesigner} from "core/models/CircuitDesigner";
+import {GetPath} from "core/utils/ComponentUtils";
 
 import {Action} from "core/actions/Action";
 import {GroupAction} from "core/actions/GroupAction"
@@ -163,7 +164,6 @@ export class SelectionTool extends DefaultTool {
     public onClick(input: Input, button: number): boolean {
         if (button !== LEFT_MOUSE_BUTTON)
             return false;
-
         const worldMousePos = this.camera.getWorldPos(input.getMousePos());
 
         let render = false;
@@ -172,7 +172,7 @@ export class SelectionTool extends DefaultTool {
         if (this.interactionHelper.click(input))
             return true;
 
-        // Clear selections if no shift key
+        // Clear selections if no shift keys
         if (!input.isShiftKeyDown()) {
             render = (this.selections.size > 0); // Render if selections were actually cleared
             this.action.add(CreateDeselectAllAction(this).execute());
@@ -198,6 +198,32 @@ export class SelectionTool extends DefaultTool {
             this.action.add(new ShiftAction(obj).execute());
             return true;
         }
+
+        return render;
+    }
+
+    public onDoubleClick(input: Input, button: number): boolean {
+        const worldMousePos = this.camera.getWorldPos(input.getMousePos());//Get current mouse positions
+
+        let render = false;
+
+        // Clear selections if no shift keys
+        if (!input.isShiftKeyDown()) {
+            render = (this.selections.size > 0); // Render if selections were actually cleared
+            this.action.add(CreateDeselectAllAction(this).execute());
+        }
+
+        const wires = this.designer.getWires().reverse();
+
+        // Check if a wire object was clicked
+        const wire = wires.find(o => o.isWithinSelectBounds(worldMousePos));
+        //If a wire is selected
+        if(wire){
+            console.log("Wire Selected!");
+            this.action.add(CreateGroupSelectAction(this,GetPath(wire)).execute());
+            return true;
+        }
+
 
         return render;
     }

--- a/app/core/ts/tools/SelectionTool.ts
+++ b/app/core/ts/tools/SelectionTool.ts
@@ -203,14 +203,12 @@ export class SelectionTool extends DefaultTool {
     }
 
     public onDoubleClick(input: Input, button: number): boolean {
-        //Get current mouse positions
         const worldMousePos = this.camera.getWorldPos(input.getMousePos());
 
         let render = false;
 
         // Clear selections if no shift keys
-        if (!input.isShiftKeyDown())
-        {
+        if (!input.isShiftKeyDown()) {
             // Render if selections were actually cleared
             render = (this.selections.size > 0);
             this.action.add(CreateDeselectAllAction(this).execute());
@@ -220,10 +218,9 @@ export class SelectionTool extends DefaultTool {
 
         // Check if a wire object was clicked
         const wire = wires.find(o => o.isWithinSelectBounds(worldMousePos));
-        //If a wire is selected
-        if(wire)
-        {
-            //Add CreateGroupSelectAction to this.action
+        // If a wire is selected
+        if (wire) {
+            // Add CreateGroupSelectAction to this.action
             this.action.add(CreateGroupSelectAction(this, GetPath(wire)).execute());
             return true;
         }

--- a/app/core/ts/tools/SelectionTool.ts
+++ b/app/core/ts/tools/SelectionTool.ts
@@ -203,13 +203,16 @@ export class SelectionTool extends DefaultTool {
     }
 
     public onDoubleClick(input: Input, button: number): boolean {
-        const worldMousePos = this.camera.getWorldPos(input.getMousePos());//Get current mouse positions
+        //Get current mouse positions
+        const worldMousePos = this.camera.getWorldPos(input.getMousePos());
 
         let render = false;
 
         // Clear selections if no shift keys
-        if (!input.isShiftKeyDown()) {
-            render = (this.selections.size > 0); // Render if selections were actually cleared
+        if (!input.isShiftKeyDown())
+        {
+            // Render if selections were actually cleared
+            render = (this.selections.size > 0);
             this.action.add(CreateDeselectAllAction(this).execute());
         }
 
@@ -218,13 +221,12 @@ export class SelectionTool extends DefaultTool {
         // Check if a wire object was clicked
         const wire = wires.find(o => o.isWithinSelectBounds(worldMousePos));
         //If a wire is selected
-        if(wire){
-            console.log("Wire Selected!");
-            this.action.add(CreateGroupSelectAction(this,GetPath(wire)).execute());
+        if(wire)
+        {
+            //Add CreateGroupSelectAction to this.action
+            this.action.add(CreateGroupSelectAction(this, GetPath(wire)).execute());
             return true;
         }
-
-
         return render;
     }
 
@@ -242,7 +244,6 @@ export class SelectionTool extends DefaultTool {
         if (input.isModifierKeyDown() && key == D_KEY) {
             const selections = Array.from(this.selections);
             const objs = selections.filter(o => o instanceof IOObject) as IOObject[];
-
             const action = new CopyGroupAction(this.designer, objs);
             const newObjs = action.getCopies();
             const comps = newObjs.getComponents();


### PR DESCRIPTION
Fix #292 

Now double clicking a wire selects all wires connected to it.

@ZHLOLin @APLunch added function public onDoubleClick(input: Input, button: number): boolean in file SelectionTool.ts