### PR TITLE
Fit screen

### DIFF
--- a/app/core/ts/actions/camera/MoveCameraAction.ts
+++ b/app/core/ts/actions/camera/MoveCameraAction.ts
@@ -21,16 +21,6 @@ export class MoveCameraAction implements Action {
         this.finalZoom = finalZoom;
     }
 
-    // Static method conveniently creates a MoveCameraAction after the
-    // camera is moved (the constructor is for before the camera is moved)
-    public static postMoveCameraAction(camera: Camera, initialPos: Vector, initialZoom: number): MoveCameraAction {
-        const action = new MoveCameraAction(camera, camera.getPos(), camera.getZoom());
-        action.initialPos = initialPos;
-        action.initialZoom = initialZoom;
-
-        return action;
-    }
-
     public execute(): Action {
         this.camera.setPos(this.finalPos);
         this.camera.setZoom(this.finalZoom);

--- a/app/core/ts/actions/camera/MoveCameraAction.ts
+++ b/app/core/ts/actions/camera/MoveCameraAction.ts
@@ -1,0 +1,48 @@
+import {Vector} from "Vector";
+import {Camera} from "math/Camera";
+import {Action} from "core/actions/Action";
+
+export class MoveCameraAction implements Action {
+    protected camera: Camera;
+
+    protected initialPos: Vector;
+    protected finalPos: Vector;
+
+    protected initialZoom: number;
+    protected finalZoom: number;
+
+    public constructor(camera: Camera, finalPos: Vector, finalZoom: number) {
+        this.camera = camera;
+
+        this.initialPos = camera.getPos();
+        this.finalPos = finalPos;
+
+        this.initialZoom = camera.getZoom();
+        this.finalZoom = finalZoom;
+    }
+
+    // Static method conveniently creates a MoveCameraAction after the
+    // camera is moved (the constructor is for before the camera is moved)
+    public static postMoveCameraAction(camera: Camera, initialPos: Vector, initialZoom: number): MoveCameraAction {
+        const action = new MoveCameraAction(camera, camera.getPos(), camera.getZoom());
+        action.initialPos = initialPos;
+        action.initialZoom = initialZoom;
+
+        return action;
+    }
+
+    public execute(): Action {
+        this.camera.setPos(this.finalPos);
+        this.camera.setZoom(this.finalZoom);
+
+        return this;
+    }
+
+    public undo(): Action {
+        this.camera.setPos(this.initialPos);
+        this.camera.setZoom(this.initialZoom);
+
+        return this;
+    }
+
+}

--- a/app/core/ts/tools/SelectionTool.ts
+++ b/app/core/ts/tools/SelectionTool.ts
@@ -1,13 +1,16 @@
-import {LEFT_MOUSE_BUTTON,
-        DELETE_KEY, BACKSPACE_KEY,
-        ESC_KEY, A_KEY, D_KEY, X_KEY} from "core/utils/Constants";
+import {LEFT_MOUSE_BUTTON, DELETE_KEY,
+        BACKSPACE_KEY, ESC_KEY,
+        A_KEY, D_KEY, F_KEY, X_KEY,
+        FIT_PADDING_RATIO} from "core/utils/Constants";
 import {Vector, V} from "Vector";
 import {Camera} from "math/Camera";
 
 import {Selectable} from "core/utils/Selectable";
 import {Input} from "core/utils/Input";
+import {FitCamera} from "core/utils/ComponentUtils";
 
 import {IOObject} from "core/models/IOObject";
+import {CullableObject} from "core/models/CullableObject";
 import {Wire} from "core/models/Wire";
 import {Component} from "core/models/Component";
 import {Node, isNode} from "core/models/Node";
@@ -206,6 +209,14 @@ export class SelectionTool extends DefaultTool {
         // If modifier key and a key are pressed, select all
         if (input.isModifierKeyDown() && key == A_KEY) {
             this.action.add(CreateGroupSelectAction(this, this.designer.getObjects()).execute());
+            return true;
+        }
+
+        if (key === F_KEY) {
+            const objs = this.selections.size === 0
+                ? (this.designer.getObjects() as CullableObject[]).concat(this.designer.getWires())
+                : this.getSelections().filter(o => o instanceof CullableObject) as CullableObject[];
+            FitCamera(this.camera, objs, FIT_PADDING_RATIO);
             return true;
         }
 

--- a/app/core/ts/tools/SelectionTool.ts
+++ b/app/core/ts/tools/SelectionTool.ts
@@ -26,6 +26,7 @@ import {CopyGroupAction} from "core/actions/CopyGroupAction";
 import {CreateGroupSnipAction} from "core/actions/addition/SplitWireAction";
 import {CreateDeleteGroupAction} from "core/actions/deletion/DeleteGroupActionFactory";
 import {CreateGroupTranslateAction} from "core/actions/transform/TranslateAction";
+import {MoveCameraAction} from "core/actions/camera/MoveCameraAction";
 
 import {Tool} from "./Tool";
 import {DefaultTool} from "./DefaultTool";
@@ -212,11 +213,18 @@ export class SelectionTool extends DefaultTool {
             return true;
         }
 
+        // Fit to screen command
         if (key === F_KEY) {
+            const initialPos = this.camera.getPos();
+            const initialZoom = this.camera.getZoom();
+
+            // Fit to selections, if any; otherwise, fit all CullableObjects
             const objs = this.selections.size === 0
                 ? (this.designer.getObjects() as CullableObject[]).concat(this.designer.getWires())
                 : this.getSelections().filter(o => o instanceof CullableObject) as CullableObject[];
+
             FitCamera(this.camera, objs, FIT_PADDING_RATIO);
+            this.action.add(MoveCameraAction.postMoveCameraAction(this.camera, initialPos, initialZoom));
             return true;
         }
 

--- a/app/core/ts/tools/SelectionTool.ts
+++ b/app/core/ts/tools/SelectionTool.ts
@@ -7,7 +7,7 @@ import {Camera} from "math/Camera";
 
 import {Selectable} from "core/utils/Selectable";
 import {Input} from "core/utils/Input";
-import {FitCamera} from "core/utils/ComponentUtils";
+import {GetCameraFit} from "core/utils/ComponentUtils";
 
 import {IOObject} from "core/models/IOObject";
 import {CullableObject} from "core/models/CullableObject";
@@ -215,16 +215,14 @@ export class SelectionTool extends DefaultTool {
 
         // Fit to screen command
         if (key === F_KEY) {
-            const initialPos = this.camera.getPos();
-            const initialZoom = this.camera.getZoom();
-
             // Fit to selections, if any; otherwise, fit all CullableObjects
             const objs = this.selections.size === 0
                 ? (this.designer.getObjects() as CullableObject[]).concat(this.designer.getWires())
                 : this.getSelections().filter(o => o instanceof CullableObject) as CullableObject[];
 
-            FitCamera(this.camera, objs, FIT_PADDING_RATIO);
-            this.action.add(MoveCameraAction.postMoveCameraAction(this.camera, initialPos, initialZoom));
+            // Get tuple of final camera position and zoom
+            const finalCamera = GetCameraFit(this.camera, objs, FIT_PADDING_RATIO);
+            this.action.add(new MoveCameraAction(this.camera, finalCamera[0], finalCamera[1]).execute());
             return true;
         }
 

--- a/app/core/ts/utils/ComponentUtils.ts
+++ b/app/core/ts/utils/ComponentUtils.ts
@@ -310,6 +310,7 @@ export function CircuitBoundingBox(all: CullableObject[]): BoundingBox {
     return new BoundingBox(min, max);
 }
 
+// Zooms and translates camera to fit objs with adjustable padding ratio
 export function FitCamera(camera: Camera, objs: CullableObject[], padding: number): void {
     const bbox = objs.length === 0
         ? new BoundingBox(EMPTY_CIRCUIT_MIN, EMPTY_CIRCUIT_MAX)

--- a/app/core/ts/utils/ComponentUtils.ts
+++ b/app/core/ts/utils/ComponentUtils.ts
@@ -310,12 +310,18 @@ export function CircuitBoundingBox(all: CullableObject[]): BoundingBox {
     return new BoundingBox(min, max);
 }
 
-// Zooms and translates camera to fit objs with adjustable padding ratio
-export function FitCamera(camera: Camera, objs: CullableObject[], padding: number): void {
+/**
+ * Calculates camera position and zoom to fit objs to
+ * the camera's view with adjustable padding. If objs
+ * is empty, uses a default size.
+ *
+ * @return Tuple of desired camera position and zoom
+ */
+export function GetCameraFit(camera: Camera, objs: CullableObject[], padding: number): [Vector, number] {
     const bbox = objs.length === 0
         ? new BoundingBox(EMPTY_CIRCUIT_MIN, EMPTY_CIRCUIT_MAX)
         : CircuitBoundingBox(objs);
-    camera.setPos(bbox.getCenter());
+    const finalPos = bbox.getCenter();
 
     const screenSize = camera.getCenter().scale(2); // Bottom right corner of screen
     const worldSize = camera.getWorldPos(screenSize).sub(camera.getWorldPos(V(0,0))); // World size of camera view
@@ -323,7 +329,9 @@ export function FitCamera(camera: Camera, objs: CullableObject[], padding: numbe
     // Determine which bbox dimension will limit zoom level
     const xRatio = bbox.getWidth()/worldSize.x;
     const yRatio = bbox.getHeight()/worldSize.y;
-    camera.zoomBy(Math.max(xRatio, yRatio) * padding);
+    const finalZoom = camera.getZoom()*Math.max(xRatio, yRatio)*padding;
+
+    return [finalPos, finalZoom];
 }
 
 // Creates a rectangle for the collision box for a port on the IC

--- a/app/core/ts/utils/Constants.ts
+++ b/app/core/ts/utils/Constants.ts
@@ -75,6 +75,6 @@ export const META_KEY = 224;
 
 export const IC_VIEWER_ZOOM_PADDING_RATIO = 1.5;
 
-export const FIT_PADDING_RATIO = 1.1;
+export const FIT_PADDING_RATIO = 1.2;
 export const EMPTY_CIRCUIT_MAX = V(GRID_SIZE*5);
 export const EMPTY_CIRCUIT_MIN = EMPTY_CIRCUIT_MAX.scale(-1);

--- a/app/core/ts/utils/Constants.ts
+++ b/app/core/ts/utils/Constants.ts
@@ -1,3 +1,5 @@
+import {V} from "Vector";
+
 export const DEBUG_CULLBOXES = false;
 export const DEBUG_PRESSABLE_BOUNDS = false;
 export const DEBUG_SELECTION_BOUNDS = false;
@@ -63,6 +65,7 @@ export const DELETE_KEY = 46;
 export const A_KEY = 65;
 export const C_KEY = 67;
 export const D_KEY = 68;
+export const F_KEY = 70;
 export const V_KEY = 86;
 export const X_KEY = 88;
 export const Y_KEY = 89;
@@ -71,3 +74,7 @@ export const COMMAND_KEY = 91;
 export const META_KEY = 224;
 
 export const IC_VIEWER_ZOOM_PADDING_RATIO = 1.5;
+
+export const FIT_PADDING_RATIO = 1.1;
+export const EMPTY_CIRCUIT_MAX = V(GRID_SIZE*5);
+export const EMPTY_CIRCUIT_MIN = EMPTY_CIRCUIT_MAX.scale(-1);

--- a/site/public/ts/digital/controllers/ICViewerController.ts
+++ b/site/public/ts/digital/controllers/ICViewerController.ts
@@ -7,7 +7,7 @@ import {Selectable} from "core/utils/Selectable";
 import {DigitalCircuitController} from "./DigitalCircuitController";
 import {DesignerController} from "site/shared/controllers/DesignerController";
 import {DigitalObjectSet} from "digital/utils/ComponentUtils";
-import {CircuitBoundingBox} from "core/utils/ComponentUtils";
+import {GetCameraFit} from "core/utils/ComponentUtils";
 import {CullableObject} from "core/models/CullableObject";
 import {V} from "Vector";
 import {IC_VIEWER_ZOOM_PADDING_RATIO} from "core/utils/Constants";
@@ -55,18 +55,14 @@ export class ICViewerController extends DesignerController {
         this.designer.addGroup(this.inside);
 
         // Adjust the camera so it all fits in the viewer
-        const bbox = CircuitBoundingBox(this.inside.toList() as CullableObject[]);
-        const min = bbox.getMin();
-        const max = bbox.getMax();
-        // Center and zoom the camera so everything fits with no distortion
-        const center = min.add(max).scale(0.5);
         const camera = this.view.getCamera();
-        camera.setPos(center);
-        // Zoom out a bit more than we need so components on edges have some breathing room
-        const canvas = this.view.getCanvas();
-        const relativeSize = max.sub(min).scale(V(1/canvas.width, 1/canvas.height));
-        const zoom = Math.max(relativeSize.x, relativeSize.y) * IC_VIEWER_ZOOM_PADDING_RATIO;
-        camera.zoomBy(zoom / camera.getZoom());
+        const finalCamera = GetCameraFit(
+            camera,
+            this.inside.toList() as CullableObject[],
+            IC_VIEWER_ZOOM_PADDING_RATIO
+        );
+        camera.setPos(finalCamera[0]);
+        camera.setZoom(finalCamera[1]);
         this.view.show();
 
         // Render

--- a/site/public/ts/shared/utils/Constants.ts
+++ b/site/public/ts/shared/utils/Constants.ts
@@ -1,9 +1,4 @@
-import {V} from "Vector";
-import {GRID_SIZE} from "core/utils/Constants";
-
 export const DEFAULT_THUMBNAIL_SIZE = 256;
 export const THUMBNAIL_ZOOM_PADDING_RATIO = 1.025;
-export const EMPTY_CIRCUIT_MAX = V(GRID_SIZE*5);
-export const EMPTY_CIRCUIT_MIN = EMPTY_CIRCUIT_MAX.scale(-1);
 
 export const OVERWRITE_CIRCUIT_MESSAGE = "Are you sure you want to overwrite your current scene?";

--- a/site/public/ts/shared/utils/ThumbnailGenerator.ts
+++ b/site/public/ts/shared/utils/ThumbnailGenerator.ts
@@ -9,8 +9,6 @@ import {CullableObject} from "core/models/CullableObject";
 
 import {CircuitView} from "site/shared/views/CircuitView";
 
-import {MoveCameraAction} from "core/actions/camera/MoveCameraAction";
-
 export class ThumbnailGenerator {
     private view: CircuitView;
     private size: number;
@@ -28,7 +26,8 @@ export class ThumbnailGenerator {
         const all = (<CullableObject[]>designer.getObjects()).concat(designer.getWires());
 
         const finalCamera = GetCameraFit(this.view.getCamera(), all, THUMBNAIL_ZOOM_PADDING_RATIO);
-        new MoveCameraAction(this.view.getCamera(), finalCamera[0], finalCamera[1]).execute();
+        this.view.getCamera().setPos(finalCamera[0]);
+        this.view.getCamera().setZoom(finalCamera[1]);
 
         // Render the circuit
         this.view.render(designer, []);

--- a/site/public/ts/shared/utils/ThumbnailGenerator.ts
+++ b/site/public/ts/shared/utils/ThumbnailGenerator.ts
@@ -25,16 +25,8 @@ export class ThumbnailGenerator {
     public generate(designer: CircuitDesigner): string {
         const all = (<CullableObject[]>designer.getObjects()).concat(designer.getWires());
 
-        // // Center and zoom the camera so everything fits
-        // //  with extra padding on sides
-        // const relativeSize = bbox.getMax().sub(bbox.getMin()).scale(1/this.size);
-        // const zoom = Math.max(relativeSize.x, relativeSize.y) * THUMBNAIL_ZOOM_PADDING_RATIO;
-
-        // // Move camera
-        // const camera = this.view.getCamera();
-        // camera.setPos(bbox.getCenter());
-        // camera.setZoom(zoom);
         FitCamera(this.view.getCamera(), all, THUMBNAIL_ZOOM_PADDING_RATIO);
+
         // Render the circuit
         this.view.render(designer, []);
 

--- a/site/public/ts/shared/utils/ThumbnailGenerator.ts
+++ b/site/public/ts/shared/utils/ThumbnailGenerator.ts
@@ -1,13 +1,15 @@
 import {DEFAULT_THUMBNAIL_SIZE,
         THUMBNAIL_ZOOM_PADDING_RATIO} from "./Constants";
 
-import {FitCamera} from "core/utils/ComponentUtils";
+import {GetCameraFit} from "core/utils/ComponentUtils";
 import {BoundingBox} from "core/utils/math/BoundingBox"
 
 import {CircuitDesigner} from "core/models/CircuitDesigner";
 import {CullableObject} from "core/models/CullableObject";
 
 import {CircuitView} from "site/shared/views/CircuitView";
+
+import {MoveCameraAction} from "core/actions/camera/MoveCameraAction";
 
 export class ThumbnailGenerator {
     private view: CircuitView;
@@ -25,7 +27,8 @@ export class ThumbnailGenerator {
     public generate(designer: CircuitDesigner): string {
         const all = (<CullableObject[]>designer.getObjects()).concat(designer.getWires());
 
-        FitCamera(this.view.getCamera(), all, THUMBNAIL_ZOOM_PADDING_RATIO);
+        const finalCamera = GetCameraFit(this.view.getCamera(), all, THUMBNAIL_ZOOM_PADDING_RATIO);
+        new MoveCameraAction(this.view.getCamera(), finalCamera[0], finalCamera[1]).execute();
 
         // Render the circuit
         this.view.render(designer, []);

--- a/site/public/ts/shared/utils/ThumbnailGenerator.ts
+++ b/site/public/ts/shared/utils/ThumbnailGenerator.ts
@@ -1,7 +1,8 @@
-import {DEFAULT_THUMBNAIL_SIZE, EMPTY_CIRCUIT_MIN,
-        EMPTY_CIRCUIT_MAX, THUMBNAIL_ZOOM_PADDING_RATIO} from "./Constants";
+import {DEFAULT_THUMBNAIL_SIZE,
+        THUMBNAIL_ZOOM_PADDING_RATIO} from "./Constants";
 
-import {CircuitBoundingBox} from "core/utils/ComponentUtils";
+import {FitCamera} from "core/utils/ComponentUtils";
+import {BoundingBox} from "core/utils/math/BoundingBox"
 
 import {CircuitDesigner} from "core/models/CircuitDesigner";
 import {CullableObject} from "core/models/CullableObject";
@@ -24,22 +25,16 @@ export class ThumbnailGenerator {
     public generate(designer: CircuitDesigner): string {
         const all = (<CullableObject[]>designer.getObjects()).concat(designer.getWires());
 
-        // Define world bounding box for empty circuits so that it shows a little bit of grid
-        const bbox = CircuitBoundingBox(all);
-        const min = (all.length == 0) ? (EMPTY_CIRCUIT_MIN) : (bbox.getMin());
-        const max = (all.length == 0) ? (EMPTY_CIRCUIT_MAX) : (bbox.getMax());
+        // // Center and zoom the camera so everything fits
+        // //  with extra padding on sides
+        // const relativeSize = bbox.getMax().sub(bbox.getMin()).scale(1/this.size);
+        // const zoom = Math.max(relativeSize.x, relativeSize.y) * THUMBNAIL_ZOOM_PADDING_RATIO;
 
-        // Center and zoom the camera so everything fits
-        //  with extra padding on sides
-        const center = min.add(max).scale(0.5);
-        const relativeSize = max.sub(min).scale(1/this.size);
-        const zoom = Math.max(relativeSize.x, relativeSize.y) * THUMBNAIL_ZOOM_PADDING_RATIO;
-
-        // Move camera
-        const camera = this.view.getCamera();
-        camera.setPos(center);
-        camera.setZoom(zoom);
-
+        // // Move camera
+        // const camera = this.view.getCamera();
+        // camera.setPos(bbox.getCenter());
+        // camera.setZoom(zoom);
+        FitCamera(this.view.getCamera(), all, THUMBNAIL_ZOOM_PADDING_RATIO);
         // Render the circuit
         this.view.render(designer, []);
 


### PR DESCRIPTION
Added function `GetCameraFit` in `ComponentUtils` that returns a position and zoom to fit a camera to an array of `CullableObject` with adjustable padding. `ThumbnailGenerator`, and the newly added F key shortcut in `SelectionTool`, now use this function.

`SelectionTool` calls the function on the selections, if any; otherwise, it calls on _all_ `CullableObject`s. It also uses the new `MoveCameraAction` to allow the user to undo fit-to-screen actions.