### PR TITLE
Center new ICs in view

### DIFF
--- a/site/public/ts/digital/controllers/ICDesignerController.ts
+++ b/site/public/ts/digital/controllers/ICDesignerController.ts
@@ -67,6 +67,7 @@ export class ICDesignerController extends DesignerController {
         const selectionTool = this.mainController.getSelectionTool();
 
         const ic = new IC(this.icdata);
+        ic.setPos(this.mainController.getCamera().getPos());
 
         this.hide();
 


### PR DESCRIPTION
Right after the IC is created by the `ICDesignerController`, it is moved to the center of the circuit controller's camera view.