### PR TITLE
Netlist generation

### DIFF
--- a/app/analog/ts/models/AnalogCircuitDesigner.ts
+++ b/app/analog/ts/models/AnalogCircuitDesigner.ts
@@ -10,6 +10,7 @@ import {AnalogObjectSet} from "analog/utils/ComponentUtils";
 import {AnalogComponent} from "./AnalogComponent";
 import {AnalogWire} from "./AnalogWire";
 import {AnalogPort} from "./ports/AnalogPort";
+import { Battery } from "./eeobjects";
 
 @serializable("AnalogCircuitDesigner")
 export class AnalogCircuitDesigner extends CircuitDesigner {
@@ -180,6 +181,257 @@ export class AnalogCircuitDesigner extends CircuitDesigner {
 
     public getXMLName(): string {
         return "circuit";
+    }
+
+
+    //Searches through all of the connections of an object, and assigns all those ports an appropiate node value.
+    //start is the index of the objects array for the object that this function should start on.
+    //NetNodes is a passed-by-reference copy of NetNodes from the giveNetList function. This function will modify the array.
+    //In the event that one of the connections is a standalone port, the function will recurse with that port as the start index
+    //Always call this function with the ground as the start node first, if it exists.
+    //Unless it's the ground, if all nodes of the start component have already been identified, this function immediately returns
+    private labelNodes(start: number, NetNodes: { name:string, xpos:number, ypos:number, nvals:number[]}[]): void {
+        let nodeVal: number = -1;
+        let nodeMin: number = -1;
+        let nodeValPos: number = -1;
+        let nodeMinPos: number = -1;
+
+        //Stores which indeces in the component's ports array has already been covered
+        //nodeTracker[i] corresponds to ports[i]. true means it's analyzed already, false means otherwise
+        let nodeTracker: boolean[] = [];
+
+        //Find the smallest node values amongst those that are labelled
+        if (NetNodes[start].name != "Ground") {
+            let flag: boolean = false;
+            for (let i:number = 0; i < NetNodes[start].nvals.length; ++i) {
+                nodeTracker.push(false);
+                if (NetNodes[start].nvals[i] > -1) {
+                    flag = true;
+                    if (nodeMin == -1) {
+                        nodeMin = NetNodes[start].nvals[i];
+                        nodeMinPos = i;
+                    }
+                    else if (NetNodes[start].nvals[i] < nodeMin){
+                        nodeMin = NetNodes[start].nvals[i];
+                        nodeMinPos = i;
+                    }
+                }
+                
+            }
+
+            if (!flag) {
+                return;
+            }
+
+            nodeVal = nodeMin;
+            nodeValPos = nodeMinPos;
+
+        }
+        else {
+            nodeMin = 0;
+            nodeMinPos = 0;
+            nodeVal = 0;
+            nodeValPos = 0;
+        }
+
+        //If the component is connected to any standalone ports, this keeps track of them for later recursion
+        let standalonePorts: number[] = [];
+
+        //If true, the rest of the ports yet to be analyzed are all unlabelled.
+        let labelFlag: boolean = false;
+
+        //Starting from the port with the smallest node label, iterate through all of that port's connections
+        //If a connection does not already have a label, label it with the same node label as the current port being analyzed
+        //i.e. if the ground is connected to a resistor, the algorithm starts on the ground's port with a label of 0.
+        //  It would detect the resistor, and label the resistor's connected port with 0.
+        //This will also fill in start component's ports with appropriate labels, if they aren't already
+        //i.e. if a battery (2 ports) only has one port labelled with 0, the other port would automatically be labelled with 1.
+        while (true) {
+
+            //modifiedNodes stores the indeces of any components that became labelled. This is used for potential recursion in the final lines of this function.
+            let modifiedNodes: number[] = [];
+
+            for (let i: number = 0; i < this.objects[start].getPorts()[nodeValPos].getWires().length; ++i) {
+                let port1Name: string = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP1Component().getName();
+                let port1XPos: number = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP1Component().getPos().x;
+                let port1YPos: number = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP1Component().getPos().y;
+                let port2Name: string = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP2Component().getName();
+                let port2XPos: number = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP2Component().getPos().x;
+                let port2YPos: number = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP2Component().getPos().y;
+
+                //Retrieves the port number of the connected node
+                let port1Num: number = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP1().getIndex();
+                let port2Num: number = this.objects[start].getPorts()[nodeValPos].getWires()[i].getP2().getIndex();
+
+                
+            
+
+                //If the component isn't a standalone port, finds and labels the appropriate port of the connected component in NetNodes
+                //If the component is a standalone port, mark it for later recursion
+                for (let k: number = 0; k < NetNodes.length; ++k) {
+                    if (NetNodes[k].name == port1Name && port1Name == "Port"
+                            && NetNodes[k].xpos == port1XPos && NetNodes[k].ypos == port1YPos && NetNodes[k].nvals[port1Num] == -1) {
+                        standalonePorts.push(k);
+                        modifiedNodes.push(k);
+                        break;
+                    }
+                    else if (NetNodes[k].name == port1Name && NetNodes[k].xpos == port1XPos && NetNodes[k].ypos == port1YPos
+                             && NetNodes[k].nvals[port1Num] == -1) {
+                        NetNodes[k].nvals[port1Num] = nodeVal;
+                        modifiedNodes.push(k);
+                        break;
+                    }
+
+                    if (NetNodes[k].name == port2Name && port2Name == "Port"
+                         && NetNodes[k].xpos == port2XPos && NetNodes[k].ypos == port2YPos && NetNodes[k].nvals[port2Num] == -1) {
+                        standalonePorts.push(k);
+                        modifiedNodes.push(k);
+                        break;
+                    }
+                    else if (NetNodes[k].name == port2Name && NetNodes[k].xpos == port2XPos && NetNodes[k].ypos == port2YPos
+                             && NetNodes[k].nvals[port2Num] == -1) {
+                        NetNodes[k].nvals[port2Num] = nodeVal;
+                        modifiedNodes.push(k);
+                        break;
+                    }
+
+                }
+            }
+            
+            if (standalonePorts.length > 0) {
+                for (let i: number = 0; i < standalonePorts.length; ++i) {
+                    NetNodes[standalonePorts[i]].nvals[0] = nodeVal;
+                    this.labelNodes(standalonePorts[i], NetNodes);
+                }
+            }
+
+            //Decide which node of the current component to analyze next.
+            //First, it goes in increasing order of nodes that have already been labelled.
+            //Then, it goes in order of how they're stored in currentPorts[], properly given them labels
+            nodeTracker[nodeValPos] = true;
+            let flag2: boolean = false;
+            let finishedFlag: boolean = true;
+            if (!labelFlag) {
+                for (let i: number = 0; i < NetNodes[start].nvals.length; ++i) {                    
+                    if (NetNodes[start].nvals[i] != -1 && NetNodes[start].nvals[i] < nodeMin && !nodeTracker[i]){
+                        flag2 = true;
+                        nodeMin = NetNodes[start].nvals[i];
+                        nodeMinPos = i;
+                    }
+                }
+
+                //If nodeMin was updated with a new value, make that the new nodeVal
+                if (flag2) {
+                    nodeVal = nodeMin;
+                    nodeValPos = nodeMinPos;
+                    finishedFlag = false;
+                }
+            }
+            //Otherwise, find the first un-labelled port. Label it, assign it to nodeVal
+            if (!flag2 || labelFlag) {
+                for (let i: number = 0; i < NetNodes[start].nvals.length; ++i) {   
+                    if (NetNodes[start].nvals[i] == -1 && !nodeTracker[i]) {
+                        nodeVal += 1;
+                        nodeValPos = i;
+                        NetNodes[start].nvals[i] = nodeVal;
+                        finishedFlag = false;
+                        break;                        
+                    }
+                }
+            }
+
+            //If no more ports can be analyzed, break off the infinite loop
+            //If the function hasn't already recursed into standalone ports, recurse into a modified component if it still has unlabelled nodes. 
+            //i.e. After the battery, it may recurse into a capacitor that is connected to the battery.
+            //This ensures proper ordering of the nodes.
+            if (finishedFlag) {
+                if (standalonePorts.length == 0) {
+                    for (let i: number = 0; i < modifiedNodes.length; ++i) {
+                        for (let k: number = 0; k < NetNodes[modifiedNodes[i]].nvals.length; ++k) {
+                            if (NetNodes[modifiedNodes[i]].nvals[k] == -1) {
+                                this.labelNodes(modifiedNodes[i], NetNodes);
+                            }
+                        }
+                    }
+                }
+
+                break;
+            }
+       }
+
+
+    }
+
+    //Converts the circuit diagram to a netlist that can then be thrown into NGSpice
+    //IMPORTANT NOTE: Node 0 MUST be the ground
+    public giveNetList(): string {
+        var s = "hey this is a netlist\n";
+
+        //Stores information on what node values should be assigned to each port of a component
+        //name is a component's name
+        //xpos and ypos are the values stored in cullTransform.pos
+        //nvals stores the node value to be used for the generated netlist.
+        //nvals[i] corresponds to the port at ports.currentPorts[i]
+        //NetNodes[i] corresponds to objects[i]
+        let NetNodes: { name:string, xpos:number, ypos:number, nvals:number[]}[] = [];
+
+
+        //Iterate through the objects[] array, add name and pos to the NetNodes array.
+        //nvals will be initialized with [-1, -1] for now
+        //The only exception is if there's a ground; the first ground that's found will be given an nval of 0.
+        //If no ground exists, the first connection of the first battery found is instead given the nval of 0.
+        let groundIndex:number = -1;
+        let batteryIndex:number = -1;
+        for (let i:number = 0; i < this.objects.length; ++i) {
+
+            NetNodes.push( { "name": this.objects[i].getDisplayName(), "xpos": this.objects[i].getPos().x, "ypos": this.objects[i].getPos().y, "nvals": [-1]} );
+            if (NetNodes[i].name == "Ground" && groundIndex == -1) {
+                groundIndex = i;
+            }
+            if (NetNodes[i].name == "Battery" && batteryIndex == -1) {
+                batteryIndex = i;
+            }
+
+            //Make sure nvals as the correct number of values according to the number of ports with the component
+            if (this.objects[i].getPorts().length > 1) {
+                for (let k:number = 1; k < this.objects[i].getPorts().length; ++k) {
+                    NetNodes[i].nvals.push(-1);
+                }
+            }
+
+        }
+        if (groundIndex > -1) {
+            NetNodes[groundIndex].nvals[0] = 0;
+        }
+        else if (batteryIndex > -1) {
+            NetNodes[batteryIndex].nvals[0] = 0;
+        }
+
+        
+
+        
+        //objects[0].ports.currentPorts[0].connections[0].p2.parent.name
+        //AKA the component pointed to by the first connection of the first port of objects[0]
+        //console.log("The tested component is: " + this.objects[0].getPorts()[0].getWires()[0].getP2Component().getName());
+
+        //console.log("The tested component's linked port is: " + this.objects[0].getPorts()[0].getWires()[0].getP2().getIndex());
+
+        //Calls labelNodes, with the index of the ground or the first battery found as the initial starting index.
+        //See the comments above this function for more info.
+        if (groundIndex > -1) {
+            this.labelNodes(groundIndex, NetNodes);
+        }
+        else if (batteryIndex > -1) {
+            this.labelNodes(batteryIndex, NetNodes);
+        }
+        else {
+            this.labelNodes(0, NetNodes);
+        }
+
+        this.objects.forEach(element => {
+            s += element.getDisplayName() + "\n"
+        });
+        return s;
     }
 
 }

--- a/app/analog/ts/models/AnalogCircuitDesigner.ts
+++ b/app/analog/ts/models/AnalogCircuitDesigner.ts
@@ -354,6 +354,11 @@ export class AnalogCircuitDesigner extends CircuitDesigner {
     //The nvals[] array within NetNodes[] must be initialized with the labelNodes() before calling this function, otherwise every component will be connected to node -1
     //The order of components in the netlist may not be desirable, as it relies on the order of the objects array. 
     //  However, this order does not functionally change the netlist. It just may not be incredibly organized
+
+    //When adding a new component to the netlist parser, do the following:
+    // - Add a new counter variable for the naming convention
+    // - Add an elseiif statement to all the others in the for loop. 
+    //      You should (hopefully) be fine if you copy-paste a pre-existing else-if statement. Just triple-check that all variables were changed appropriately!
     private stringifyNetList(NetNodes: { name:string, xpos:number, ypos:number, nvals:number[]}[]): string {
         //First line is always the title of the netlist
         let result: string = "OpenCircuits Outputted Netlist\n";

--- a/tests/app/analog/NetlistTests.md
+++ b/tests/app/analog/NetlistTests.md
@@ -1,0 +1,107 @@
+Testing for generated netlists is tough, as there may be several valid netlists for a given circuit. This file describes the test cases used to test the functionality of the netlist generation.  
+
+To quickly visualize a generated netlist as a diagram, [NetlistViewer](https://sourceforge.net/projects/netlistviewer/) gets the job done. However, it requires a couple extra lines in the netlist. The code to generate these extra lines is commented out by default. To uncomment them for ease of testing, they can be found in the stringifyNetList() function of app/analog/ts/models/AnalogCircuitDesigner.ts  
+
+# Test cases
+The following is a set of links to images hosted on imgur, showing the circuits that have been tested. These are followed be an example of a possible valid netlist. If there is a better method of representing these test cases, please feel free to replace the imgur links with that representation.  
+Note that order of components does not matter, nor does the naming conventions of these components.
+
+### [Standard uses with the battery, resistor, and capacitor](https://imgur.com/a/zOw51KK)
+RC time-constant circuit - standalone ports
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 2 0 3.3k
+    c1 2 1 47u ic=0
+    c2 2 1 22u ic=0
+    .end
+
+RC time-constant circuit - no standalone ports
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 2 0 3.3k
+    c1 2 1 47u ic=0
+    c2 2 1 22u ic=0
+    .end
+
+Multiple-source DC resistor network circuit
+
+    OpenCircuits Outputted Netlist
+    v1 3 0 dc 24
+    v2 1 0 dc 15
+    r1 2 3 10k
+    r2 1 2 8.1k
+    r3 0 2 4.7k
+    .end
+
+Simple series circuit
+
+    OpenCircuits Outputted Netlist
+    r1 2 1 5k
+    r2 3 2 5k
+    r3 3 0 5k
+    v1 1 0 dc 10
+    .end
+
+Simple parallel circuit - standalone ports
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 0 1 5k
+    r2 0 1 10k
+    .end
+
+Simple parallel circuit - no standalone ports
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 0 1 5k
+    r2 0 1 10k
+    .end
+
+### [Ground component tests](https://imgur.com/a/ANqinAi)
+The addition of a ground component does not fundamentally change how a netlist is formatted, as a netlist interpreter always assumes node 0 is the ground. i.e. the ground component is not explicitly defined in a netlist.  
+
+There are also tests using multiple grounds. Note that all grounds must be on the same wire, i.e. node of a netlist. This is a rule for circuit building as a whole. Having grounds on entirely separate parts of circuit causes undefined behavior for netlists regardless.
+
+Simple series circuit
+
+    OpenCircuits Outputted Netlist
+    r1 2 1 5k
+    r2 3 2 5k
+    r3 3 0 5k
+    v1 1 0 dc 10
+    .end
+
+Simple parallel circuit - standalone ports
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 0 1 5k
+    r2 0 1 10k
+    .end
+
+Simple parallel circuit - no standalone ports
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 0 1 5k
+    r2 0 1 10k
+    .end
+
+Simple parallel circuit - standalone ports, multiple grounds
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 0 1 5k
+    r2 0 1 10k
+    .end
+
+Simple parallel circuit - no standalone ports, multiple grounds
+
+    OpenCircuits Outputted Netlist
+    v1 1 0 dc 10
+    r1 0 1 5k
+    r2 0 1 10k
+    .end


### PR DESCRIPTION
Adapted updateNetList() so it would call giveNetList(). Since there's a separate function for getNetList(), maybe we can make giveNetList() private?  

The merge deleted a bunch of commented out code in AnalogCircuitDesigner.ts. I don't know how important that code may be. Check the commit where I merged AnalogWork to NetlistGen to see what commented out code I'm referring to.  

A markdown file detailing test cases was put into a new folder, tests/app/analog