### PR TITLE
Text wrap fix, also add required package to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@types/react-redux": "^7.1.16",
     "customize-cra": "^1.0.0",
     "node-sass": "^5.0.0",
     "react-app-rewired": "^2.1.8",

--- a/src/site/shared/containers/ItemNav/index.scss
+++ b/src/site/shared/containers/ItemNav/index.scss
@@ -43,7 +43,7 @@ $tab-padding: 8px;
         font-weight: bold;
 
         width: calc(49% - 5px);
-        padding: 1vh 1vh 1vh 1vh;
+        padding: 10px 10px 10px 10px;
 
         cursor: pointer;
         transition: 0.3s;

--- a/src/site/shared/containers/ItemNav/index.scss
+++ b/src/site/shared/containers/ItemNav/index.scss
@@ -43,7 +43,7 @@ $tab-padding: 8px;
         font-weight: bold;
 
         width: calc(49% - 5px);
-        padding: 10px 10px 10px 10px;
+        padding: 10px;
 
         cursor: pointer;
         transition: 0.3s;


### PR DESCRIPTION
This sets the padding around the components in the itemnav to a fixed size, fixing #567 
This adds ```@types/react-redux``` to package.json, which was necessary for me to be able to run npm start