### PR TITLE
Split wire fix

### DIFF
--- a/src/app/core/actions/addition/SplitWireAction.ts
+++ b/src/app/core/actions/addition/SplitWireAction.ts
@@ -11,10 +11,10 @@ import {PlaceAction, DeleteAction} from "./PlaceAction";
 export function CreateSplitWireAction(designer: CircuitDesigner, w: Wire, port: Node): GroupAction {
     const action = new GroupAction();
 
-    action.add(new DisconnectAction(designer, w));
-    action.add(new PlaceAction(designer, port));
-    action.add(new ConnectionAction(designer, w.getP1(), port.getP1()));
-    action.add(new ConnectionAction(designer, port.getP2(), w.getP2()));
+    action.add(new DisconnectAction(designer, w).execute());
+    action.add(new PlaceAction(designer, port).execute());
+    action.add(new ConnectionAction(designer, w.getP1(), port.getP1()).execute());
+    action.add(new ConnectionAction(designer, port.getP2(), w.getP2()).execute());
 
     return action;
 }

--- a/src/app/core/tools/SplitWireTool.ts
+++ b/src/app/core/tools/SplitWireTool.ts
@@ -56,6 +56,9 @@ export const SplitWireTool: Tool = (() => {
             action.add(CreateSplitWireAction(designer, wire, port));
 
             info.currentlyPressedObject = port;
+
+            // Set initial position
+            initialPosition = new Vector(camera.getWorldPos(input.getMousePos()));
         },
         onDeactivate({}: Event, {history}: CircuitInfo): void {
             history.add(action.add(new TranslateAction([port], [initialPosition], [port.getPos()])));

--- a/src/app/core/tools/SplitWireTool.ts
+++ b/src/app/core/tools/SplitWireTool.ts
@@ -15,7 +15,7 @@ import {Node, Wire} from "core/models";
 
 
 export const SplitWireTool: Tool = (() => {
-    let initalPosition: Vector;
+    let initialPosition: Vector;
     let port: Node;
     let action: GroupAction;
 
@@ -58,7 +58,7 @@ export const SplitWireTool: Tool = (() => {
             info.currentlyPressedObject = port;
         },
         onDeactivate({}: Event, {history}: CircuitInfo): void {
-            history.add(action.add(new TranslateAction([port], [initalPosition], [port.getPos()])));
+            history.add(action.add(new TranslateAction([port], [initialPosition], [port.getPos()])));
         },
 
 
@@ -74,12 +74,12 @@ export const SplitWireTool: Tool = (() => {
             const dPos = worldMousePos.sub(worldMouseDownPos);
 
             // Calculate new position and et snapped positions if shift is held
-            const curPosition = initalPosition.add(dPos);
+            const curPosition = initialPosition.add(dPos);
             const newPosition = input.isShiftKeyDown() ? snap(curPosition) : curPosition;
 
             // Execute translate but don't save to group
             //  action since we do that onDeactivate
-            new TranslateAction([port], [initalPosition], [newPosition]).execute();
+            new TranslateAction([port], [initialPosition], [newPosition]).execute();
 
             return true;
         }

--- a/src/app/core/tools/SplitWireTool.ts
+++ b/src/app/core/tools/SplitWireTool.ts
@@ -58,7 +58,7 @@ export const SplitWireTool: Tool = (() => {
             info.currentlyPressedObject = port;
 
             // Set initial position
-            initialPosition = new Vector(camera.getWorldPos(input.getMousePos()));
+            initialPosition = camera.getWorldPos(input.getMousePos());
         },
         onDeactivate({}: Event, {history}: CircuitInfo): void {
             history.add(action.add(new TranslateAction([port], [initialPosition], [port.getPos()])));

--- a/src/app/core/tools/SplitWireTool.ts
+++ b/src/app/core/tools/SplitWireTool.ts
@@ -53,7 +53,7 @@ export const SplitWireTool: Tool = (() => {
             // Set wireport as selection and being pressed
             action.add(CreateDeselectAllAction(selections).execute());
             action.add(new SelectAction(selections, port).execute());
-            action.add(CreateSplitWireAction(designer, wire, port).execute());
+            action.add(CreateSplitWireAction(designer, wire, port));
 
             info.currentlyPressedObject = port;
         },


### PR DESCRIPTION
Closes issue #588

Relocates execution of SplitWireAction to inside the creation of the group, rather than after the creation (as the later actions in the group could not properly be created before the prior actions were executed).

Also added proper creation of the vector holding the initial position of the node when performing the split wire action (in SplitWireTool). (also renamed said vector from initalPosition to initialPosition).

Remaining issue from this is that now wires can be split, but after doing so existing nodes mid-wire cannot be reselected and moved (aside from typing in number coordinates). Dragging on an existing node just creates a new one. However I believe this issue is arising from a separate area of the code.