### PR TITLE
Wire double click fix

### DIFF
--- a/src/site/shared/containers/SelectionPopup/index.tsx
+++ b/src/site/shared/containers/SelectionPopup/index.tsx
@@ -1,6 +1,6 @@
 import {useLayoutEffect, useState} from "react";
 
-import {HEADER_HEIGHT} from "shared/utils/Constants";
+import {HEADER_HEIGHT, DOUBLE_CLICK_DURATION} from "shared/utils/Constants";
 
 import {V} from "Vector";
 import {Camera} from "math/Camera";
@@ -70,7 +70,7 @@ export function SelectionPopup({info, modules}: Props) {
                     { 
                         return { ...prevState, clickthrough }
                     }),
-                500);
+                DOUBLE_CLICK_DURATION);
             }
 
             lastPos = pos;

--- a/src/site/shared/containers/SelectionPopup/index.tsx
+++ b/src/site/shared/containers/SelectionPopup/index.tsx
@@ -68,7 +68,7 @@ export function SelectionPopup({info, modules}: Props) {
                 clickthrough = false;
                 setTimeout(() => setState((prevState) => 
                     { 
-                        return { visible: prevState.visible, pos: prevState.pos, clickthrough }
+                        return { ...prevState, clickthrough }
                     }),
                 500);
             }

--- a/src/site/shared/containers/SelectionPopup/index.tsx
+++ b/src/site/shared/containers/SelectionPopup/index.tsx
@@ -26,14 +26,14 @@ export function SelectionPopup({info, modules}: Props) {
     const [state, setState] = useState({
         visible: false,
         pos: V(),
-        clickthrough: false
+        clickThrough: false
     });
 
     useLayoutEffect(() => {
         let lastPos = V();
         let lastVisible = false;
         let dragging = false;
-        let clickthrough = false;
+        let clickThrough = false;
 
         const getPos = () => {
             const pos = camera.getScreenPos(selections.midpoint(true));
@@ -50,7 +50,7 @@ export function SelectionPopup({info, modules}: Props) {
 
             // Let user click through box so it doesn't block a double click
             if (ev.type === "click")
-                clickthrough = true
+                clickThrough = true;
 
             const pos = getPos();
 
@@ -61,16 +61,15 @@ export function SelectionPopup({info, modules}: Props) {
             if (pos === lastPos && visible === lastVisible)
                 return;
 
-            setState({ pos, visible, clickthrough });
+            setState({ pos, visible, clickThrough });
 
             // Set up a callback that will make the box clickable if it's currently not clickable
-            if (clickthrough === true) {
-                clickthrough = false;
-                setTimeout(() => setState((prevState) => 
-                    { 
-                        return { ...prevState, clickthrough }
-                    }),
-                DOUBLE_CLICK_DURATION);
+            if (clickThrough) {
+                clickThrough = false;
+                setTimeout(() => 
+                    setState((prevState) => ({ ...prevState, clickThrough })), 
+                    DOUBLE_CLICK_DURATION
+                );
             }
 
             lastPos = pos;
@@ -91,7 +90,7 @@ export function SelectionPopup({info, modules}: Props) {
                 left: `${state.pos.x}px`,
                 top:  `${state.pos.y + HEADER_HEIGHT}px`,
                 visibility: (state.visible ? "visible": "hidden"),
-                pointerEvents: (state.clickthrough ? "none" : "auto")
+                pointerEvents: (state.clickThrough ? "none" : "auto")
              }}
              tabIndex={-1}>
             <TitleModule selections={selections}

--- a/src/site/shared/containers/SelectionPopup/index.tsx
+++ b/src/site/shared/containers/SelectionPopup/index.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect, useState, ComponentState} from "react";
+import {useLayoutEffect, useState} from "react";
 
 import {HEADER_HEIGHT} from "shared/utils/Constants";
 

--- a/src/site/shared/utils/Constants.ts
+++ b/src/site/shared/utils/Constants.ts
@@ -1,2 +1,3 @@
 
 export const HEADER_HEIGHT = 65; // px
+export const DOUBLE_CLICK_DURATION = 500; // ms


### PR DESCRIPTION
Closes issue #521 

Allows users to click through a SelectionPopup for 500ms after it is shown. After that point, it becomes clickable. This will let the user double click a wire to select all connected wires, even if the wires are in a configuration where normally the box popup would block the wire.

I tested this out with the fix to wire selection that was just merged to master and was able to double click through it for half a second. 