### PR TITLE
Menu now closes if you click the same menu icon again

### DIFF
--- a/src/site/shared/containers/Header/Right/Dropdown.tsx
+++ b/src/site/shared/containers/Header/Right/Dropdown.tsx
@@ -30,7 +30,7 @@ export function Dropdown(props: Props) {
 
     // Check for clicking outside of the menu as to call onClose
     useEffect(() => {
-        function onClick(ev: MouseEvent) {
+        function onWindowClick(ev: MouseEvent) {
             if (!open || onClose === undefined)
                 return;
 
@@ -40,17 +40,17 @@ export function Dropdown(props: Props) {
         }
 
         // Add listener on start
-        window.addEventListener("click", onClick);
+        window.addEventListener("click", onWindowClick);
 
         // Remove listener for cleanup
-        return () => window.removeEventListener("click", onClick);
+        return () => window.removeEventListener("click", onWindowClick);
     });
 
     return (
         <div className="header__right__dropdown">
             <button className={`header__right__dropdown__button ${open ? "white" : ""}`}
                     title={btnInfo.title}
-                    onClick={onClick}>
+                    onClick={open ? onClose : onClick}>
                 <img src={btnInfo.src} height="100%" alt={btnInfo.title} />
             </button>
             <div className={`header__right__dropdown__content ${open ? "" : "hide"}`}>

--- a/src/site/shared/state/Header/reducers.ts
+++ b/src/site/shared/state/Header/reducers.ts
@@ -13,8 +13,7 @@ export function headerReducer(state = initialState, action: AllSharedActions): H
         case OPEN_HEADER_MENU_ID:
             return {
                 ...state,
-                // Close the menu by clicking on its icon while it is open
-                curMenu: ((state.curMenu === action.menu) ? ("none") : (action.menu))
+                curMenu: action.menu
             };
         case OPEN_HEADER_POPUP_ID:
             return {

--- a/src/site/shared/state/Header/reducers.ts
+++ b/src/site/shared/state/Header/reducers.ts
@@ -13,7 +13,8 @@ export function headerReducer(state = initialState, action: AllSharedActions): H
         case OPEN_HEADER_MENU_ID:
             return {
                 ...state,
-                curMenu: action.menu
+                // Close the menu by clicking on its icon while it is open
+                curMenu: ((state.curMenu === action.menu) ? ("none") : (action.menu))
             };
         case OPEN_HEADER_POPUP_ID:
             return {


### PR DESCRIPTION
Previously when a header menu was open, say the download menu, clicking the download icon again wouldn't close it. Now it does, just like it does on opencircuits.io
I figured out how to fix it before I even got around to creating an issue for it so there is no issue to link to
Fixes #611 