### PR TITLE
Google Auth verifies audience

### DIFF
--- a/src/server/auth/google/google.go
+++ b/src/server/auth/google/google.go
@@ -1,26 +1,30 @@
 package google
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"log"
-	"net/http"
 
 	"github.com/OpenCircuits/OpenCircuits/site/go/auth"
 	"github.com/gin-gonic/gin"
 	"google.golang.org/api/oauth2/v2"
+	"google.golang.org/api/option"
 )
 
 type authenticationMethod struct {
-	config  oauth2Config
+	config  oauth2ConfigWrapper
 	service *oauth2.Service
 }
 
 // Credentials which stores google ids.
 type oauth2Config struct {
-	ID          string `json:"id"`
-	Secret      string `json:"secret"`
-	RedirectURL string `json:"redirectURL"`
+	ClientId  string `json:"client_id"`
+	ProjectId string `json:"project_id"`
+}
+type oauth2ConfigWrapper struct {
+	Web oauth2Config `json:"web"`
 }
 
 func (g authenticationMethod) RegisterHandlers(engine *gin.Engine) {
@@ -34,15 +38,15 @@ func New(configPath string) auth.AuthenticationMethod {
 		panic(err)
 	}
 
-	var cred oauth2Config
+	var cred oauth2ConfigWrapper
 	err = json.Unmarshal(file, &cred)
 	if err != nil {
 		log.Printf("Error unmarshalling credentials json: %v\n", err)
 		panic(err)
 	}
 
-	client := &http.Client{}
-	oauth2Service, err := oauth2.New(client)
+	// The IdToken endpoint does not need authentication
+	oauth2Service, err := oauth2.NewService(context.Background(), option.WithoutAuthentication())
 	if err != nil {
 		panic(err)
 	}
@@ -56,9 +60,14 @@ func New(configPath string) auth.AuthenticationMethod {
 func (g authenticationMethod) ExtractIdentity(token string) (string, error) {
 	// This is poorly documented, so the code for verifying a token is credit to
 	// https://stackoverflow.com/a/36717411/2972004
+	// NOTE: This should be replaced with manual JWT verification. This endpoint
+	//	is only designed for debugging and validation
 	tokenInfo, err := g.service.Tokeninfo().IdToken(token).Do()
 	if err != nil {
 		return "", err
+	}
+	if tokenInfo.IssuedTo != g.config.Web.ClientId {
+		return "", errors.New("invalid audience")
 	}
 	return "google_" + tokenInfo.UserId, nil
 }

--- a/src/server/auth/google/google.go
+++ b/src/server/auth/google/google.go
@@ -20,8 +20,8 @@ type authenticationMethod struct {
 
 // Credentials which stores google ids.
 type oauth2Config struct {
-	ClientId  string `json:"client_id"`
-	ProjectId string `json:"project_id"`
+	ClientID  string `json:"client_id"`
+	ProjectID string `json:"project_id"`
 }
 type oauth2ConfigWrapper struct {
 	Web oauth2Config `json:"web"`
@@ -66,7 +66,7 @@ func (g authenticationMethod) ExtractIdentity(token string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if tokenInfo.IssuedTo != g.config.Web.ClientId {
+	if tokenInfo.IssuedTo != g.config.Web.ClientID {
 		return "", errors.New("invalid audience")
 	}
 	return "google_" + tokenInfo.UserId, nil


### PR DESCRIPTION
also
Fixes #343 

The token validation was not verifying that the token was for OpenCircuits.  This patch fixes google authentication so that tokens from 3rd parties cannot be used to authenticate with OpenCircuits.

Note: I verified this works locally, but the nightly / production environment may need to be tweaked.  The `.json` file with the API client id / secret should be in this format, which is how it is when downloaded from gcloud:
```json
{
	"web": {
		"client_id": "<client_id_prefix>.apps.googleusercontent.com",
		"project_id": "<project_id>",
		"auth_uri": "https://accounts.google.com/o/oauth2/auth",
		"token_uri": "https://oauth2.googleapis.com/token",
		"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
		"client_secret": "<secret>",
		"javascript_origins": [ ... ]
	}
}
```
However, only the `client_id` field is actually used at this time.