### PR TITLE
Prevent Copy-On-Save behavior for loaded user circuits

### DIFF
--- a/src/site/pages/digital/src/utils/CircuitInfo/DigitalCircuitInfoHelpers.ts
+++ b/src/site/pages/digital/src/utils/CircuitInfo/DigitalCircuitInfoHelpers.ts
@@ -49,9 +49,9 @@ export function GetDigitalCircuitInfoHelpers(store: AppStore, canvas: RefObject<
 
             renderer.render();
 
-            // Set name, reset id, and set unsaved
+            // Set name, id, and set unsaved
             store.dispatch(SetCircuitName(metadata.name));
-            store.dispatch(SetCircuitId(""));
+            store.dispatch(SetCircuitId(metadata.id));
             store.dispatch(SetCircuitSaved(false));
         },
 


### PR DESCRIPTION
When saving a circuit that was loaded, either from the examples or the user's circuit list, the circuit always is copied on the first save.  This is correct for example circuits, but not desirable for user circuits.

This patch sets the local circuit ID from the retrieved circuit's ID so that the circuit is saved rather than copied.  Example circuits' IDs are empty, so they are copied when saved the first time.