### PR TITLE
Fixed bus option not disappearing after usage.

### DIFF
--- a/src/site/shared/containers/SelectionPopup/index.tsx
+++ b/src/site/shared/containers/SelectionPopup/index.tsx
@@ -79,10 +79,9 @@ export function SelectionPopup({info, modules}: Props) {
         if (!input)
             return;
         input.addListener(update);
-        /**
-         * Fixes issue #753. This is necessary because when a bus is made, no change is recorded in the system, so it does not
-         * update to remove the bus button as intended. The function below ensures that when a bus is made, an upate is called.
-         */
+
+        // Fixes issue #753. This is necessary because when a bus is made, no change is recorded in the system, so it does not
+        // update to remove the bus button as intended. The function below ensures that when a bus is made, an upate is called.
         designer.addCallback(() => update({type:"unknown"}, true));
 
         return () => {console.log("I SHOULD NOT BE HERE")}


### PR DESCRIPTION
Added a Callback to update the Selection Popup after creating a bus. It does not update normally due to adding wires not being a condition to update, so another function was required.

Fixes #753 