### PR TITLE
Fixed mouse and wire interaction

### DIFF
--- a/src/app/core/tools/SplitWireTool.ts
+++ b/src/app/core/tools/SplitWireTool.ts
@@ -1,4 +1,4 @@
-import {GRID_SIZE}  from "core/utils/Constants";
+import {GRID_SIZE, LEFT_MOUSE_BUTTON}  from "core/utils/Constants";
 import {V, Vector} from "Vector";
 
 import {Event}       from "core/utils/Events";
@@ -29,7 +29,7 @@ export const SplitWireTool: Tool = (() => {
             if (locked)
                 return false;
             // Activate if the user dragged over a wire with 1 touch/finger
-            return (event.type === "mousedrag" &&
+            return (event.type === "mousedrag" && event.button === LEFT_MOUSE_BUTTON &&
                     input.getTouchCount() === 1 &&
                     currentlyPressedObject instanceof Wire);
         },

--- a/src/app/core/tools/WiringTool.ts
+++ b/src/app/core/tools/WiringTool.ts
@@ -1,3 +1,4 @@
+import {LEFT_MOUSE_BUTTON} from "core/utils/Constants";
 import {Vector} from "Vector";
 
 import {Event}       from "core/utils/Events";
@@ -51,7 +52,7 @@ export const WiringTool = (() => {
                 return false;
             const ports = findPorts(info);
             // Activate if the user drags or clicks on a port
-            return ((event.type === "mousedown" && input.getTouchCount() === 1) ||
+            return ((event.type === "mousedown" && event.button === LEFT_MOUSE_BUTTON && input.getTouchCount() === 1) ||
                     (event.type === "click")) &&
                     ports.length > 0 &&
                     designer.createWire(ports[0], undefined) !== undefined;

--- a/src/app/tests/digital/utils/tools/NodeandWireInteraction.test.ts
+++ b/src/app/tests/digital/utils/tools/NodeandWireInteraction.test.ts
@@ -1,0 +1,101 @@
+import "jest";
+import "test/helpers/Extensions";
+
+import {RIGHT_MOUSE_BUTTON, MIDDLE_MOUSE_BUTTON} from "core/utils/Constants";
+
+import {V} from "Vector";
+
+import {Switch, LED} from "digital/models/ioobjects";
+
+import {Setup}      from "test/helpers/Setup";
+import {GetHelpers} from "test/helpers/Helpers";
+import {DigitalComponent} from "digital/models";
+
+describe("Node and Wire Interaction", () => {
+    const {designer, input} = Setup();
+    const {Place, Connect} = GetHelpers({designer});
+
+    function expectNotToBeConnected(obj1: DigitalComponent, obj2: DigitalComponent): void {
+        const connections = obj1.getOutputs().map((w) => w.getOutputComponent());
+        expect(connections).not.toContain(obj2);
+    }
+
+    /*test("Drag to Connect Switch -> LED with Middle Mouse", () => {
+        const [sw, led] = Place(new Switch(), new LED());
+        led.setPos(V(100, 0));
+
+        input.drag(sw.getOutputPort(0).getWorldTargetPos(),
+                   led.getInputPort(0).getWorldTargetPos(), MIDDLE_MOUSE_BUTTON);
+
+        expectNotToBeConnected(sw, led);
+    });*/
+
+    test("Drag to Connect Switch -> LED with Right Mouse", () => {
+        const [sw, led] = Place(new Switch(), new LED());
+        led.setPos(V(100, 0));
+
+        input.drag(sw.getOutputPort(0).getWorldTargetPos(),
+                   led.getInputPort(0).getWorldTargetPos(), RIGHT_MOUSE_BUTTON);
+
+        expectNotToBeConnected(sw, led);
+    });
+
+    test("Connect Switch -> LED then Split Twice into Snapped Rectangle With Right Mouse Button", () => {
+        const [sw, led] = Place(new Switch(), new LED());
+        sw.setPos(V(-66, 0)); // 66 is from size of Switch (62)/2 + IO_PORT_LENGTH (35)
+        led.setPos(V(400, -100));
+
+        // Connect Switch -> LED
+        input.drag(sw.getOutputPort(0).getWorldTargetPos(),
+                   led.getInputPort(0).getWorldTargetPos());
+
+        expect(led.getInputs()).toHaveLength(1);
+        expect(sw.getOutputs()).toHaveLength(1);
+
+        // Split twice
+        input.press(sw.getOutputs()[0].getShape().getPos(0.5), RIGHT_MOUSE_BUTTON)
+                .moveTo(V(0, 100))
+                .release();
+        input.press(led.getInputs()[0].getShape().getPos(0.5), RIGHT_MOUSE_BUTTON)
+                .moveTo(V(400, 100))
+                .release();
+
+        const port1 = sw.getOutputs()[0].getOutputComponent();
+        expect(port1.getInputs()[0].isStraight()).toBe(false);
+        expect(port1.getOutputs()[0].isStraight()).toBe(false);
+
+        const port2 = led.getInputs()[0].getInputComponent();
+        expect(port2.getInputs()[0].isStraight()).toBe(false);
+        expect(port2.getOutputs()[0].isStraight()).toBe(false);
+    });
+    
+    /*
+    test("Connect Switch -> LED then Split Twice into Snapped With Middle Mouse Button", () => {
+        const [sw, led] = Place(new Switch(), new LED());
+        sw.setPos(V(-66, 0));
+        led.setPos(V(400, -100));
+
+        // Connect Switch -> LED
+        input.drag(sw.getOutputPort(0).getWorldTargetPos(),
+                   led.getInputPort(0).getWorldTargetPos());
+
+        expect(led.getInputs()).toHaveLength(1);
+        expect(sw.getOutputs()).toHaveLength(1);
+
+        // Split twice
+        input.press(sw.getOutputs()[0].getShape().getPos(0.5), MIDDLE_MOUSE_BUTTON)
+                .moveTo(V(0, 100))
+                .release();
+        input.press(led.getInputs()[0].getShape().getPos(0.5), MIDDLE_MOUSE_BUTTON)
+                .moveTo(V(400, 100))
+                .release();
+
+        const port1 = sw.getOutputs()[0].getOutputComponent();
+        expect(port1.getInputs()[0].isStraight()).toBe(false);
+        expect(port1.getOutputs()[0].isStraight()).toBe(false);
+
+        const port2 = led.getInputs()[0].getInputComponent();
+        expect(port2.getInputs()[0].isStraight()).toBe(false);
+        expect(port2.getOutputs()[0].isStraight()).toBe(false);
+    });*/
+});

--- a/src/app/tests/digital/utils/tools/NodeandWireInteraction.test.ts
+++ b/src/app/tests/digital/utils/tools/NodeandWireInteraction.test.ts
@@ -5,7 +5,7 @@ import {RIGHT_MOUSE_BUTTON, MIDDLE_MOUSE_BUTTON} from "core/utils/Constants";
 
 import {V} from "Vector";
 
-import {Switch, LED} from "digital/models/ioobjects";
+import {Switch, LED, DigitalNode} from "digital/models/ioobjects";
 
 import {Setup}      from "test/helpers/Setup";
 import {GetHelpers} from "test/helpers/Helpers";
@@ -20,15 +20,12 @@ describe("Node and Wire Interaction", () => {
         expect(connections).not.toContain(obj2);
     }
 
-    /*test("Drag to Connect Switch -> LED with Middle Mouse", () => {
-        const [sw, led] = Place(new Switch(), new LED());
-        led.setPos(V(100, 0));
+    afterEach(() => {
+        // Clear circuit
+        designer.reset();
+    });
 
-        input.drag(sw.getOutputPort(0).getWorldTargetPos(),
-                   led.getInputPort(0).getWorldTargetPos(), MIDDLE_MOUSE_BUTTON);
-
-        expectNotToBeConnected(sw, led);
-    });*/
+    
 
     test("Drag to Connect Switch -> LED with Right Mouse", () => {
         const [sw, led] = Place(new Switch(), new LED());
@@ -61,41 +58,48 @@ describe("Node and Wire Interaction", () => {
                 .release();
 
         const port1 = sw.getOutputs()[0].getOutputComponent();
-        expect(port1.getInputs()[0].isStraight()).toBe(false);
-        expect(port1.getOutputs()[0].isStraight()).toBe(false);
+        expect(port1).not.toBeInstanceOf(DigitalNode);
 
         const port2 = led.getInputs()[0].getInputComponent();
-        expect(port2.getInputs()[0].isStraight()).toBe(false);
-        expect(port2.getOutputs()[0].isStraight()).toBe(false);
+        expect(port2).not.toBeInstanceOf(DigitalNode);
     });
     
-    /*
-    test("Connect Switch -> LED then Split Twice into Snapped With Middle Mouse Button", () => {
+    
+    
+    test("Connect Switch -> LED then Split Twice into Snapped Rectangle With Middle Mouse Button", () => {
         const [sw, led] = Place(new Switch(), new LED());
-        sw.setPos(V(-66, 0));
+        sw.setPos(V(-66, 0)); // 66 is from size of Switch (62)/2 + IO_PORT_LENGTH (35)
         led.setPos(V(400, -100));
-
+        
         // Connect Switch -> LED
         input.drag(sw.getOutputPort(0).getWorldTargetPos(),
-                   led.getInputPort(0).getWorldTargetPos());
-
+        led.getInputPort(0).getWorldTargetPos());
+        
         expect(led.getInputs()).toHaveLength(1);
         expect(sw.getOutputs()).toHaveLength(1);
-
+        
         // Split twice
         input.press(sw.getOutputs()[0].getShape().getPos(0.5), MIDDLE_MOUSE_BUTTON)
-                .moveTo(V(0, 100))
-                .release();
+        .moveTo(V(0, 100))
+        .release();
         input.press(led.getInputs()[0].getShape().getPos(0.5), MIDDLE_MOUSE_BUTTON)
-                .moveTo(V(400, 100))
-                .release();
-
+        .moveTo(V(400, 100))
+        .release();
+        
         const port1 = sw.getOutputs()[0].getOutputComponent();
-        expect(port1.getInputs()[0].isStraight()).toBe(false);
-        expect(port1.getOutputs()[0].isStraight()).toBe(false);
-
+        expect(port1).not.toBeInstanceOf(DigitalNode);
+        
         const port2 = led.getInputs()[0].getInputComponent();
-        expect(port2.getInputs()[0].isStraight()).toBe(false);
-        expect(port2.getOutputs()[0].isStraight()).toBe(false);
-    });*/
+        expect(port2).not.toBeInstanceOf(DigitalNode);
+    });
+    
+    test("Drag to Connect Switch -> LED with Middle Mouse", () => {
+        const [sw, led] = Place(new Switch(), new LED());
+        led.setPos(V(100, 0));
+    
+        input.drag(sw.getOutputPort(0).getWorldTargetPos(),
+                   led.getInputPort(0).getWorldTargetPos(), MIDDLE_MOUSE_BUTTON);
+    
+        expectNotToBeConnected(sw, led);
+    });
 });


### PR DESCRIPTION
When a node is clicked and dragged with the middle and right mouse buttons, it no longer creates a wire. When a created wire is clicked and dragged with the right mouse button, the wire no longer splits. Both buttons now work as intended.

Fixes #779 