### PR TITLE
Undo errors

### DIFF
--- a/src/app/digital/actions/ports/CoderPortChangeAction.ts
+++ b/src/app/digital/actions/ports/CoderPortChangeAction.ts
@@ -50,6 +50,7 @@ export class CoderPortChangeAction implements Action {
     public undo(): Action {
         // Change size back first
         this.changeSize(this.initialCount);
+        
         this.outputPortAction.undo();
         this.inputPortAction.undo();
         return this;

--- a/src/app/digital/actions/ports/CoderPortChangeAction.ts
+++ b/src/app/digital/actions/ports/CoderPortChangeAction.ts
@@ -50,7 +50,7 @@ export class CoderPortChangeAction implements Action {
     public undo(): Action {
         // Change size back first
         this.changeSize(this.initialCount);
-        
+
         this.outputPortAction.undo();
         this.inputPortAction.undo();
         return this;

--- a/src/app/digital/actions/ports/CoderPortChangeAction.ts
+++ b/src/app/digital/actions/ports/CoderPortChangeAction.ts
@@ -25,12 +25,12 @@ export class CoderPortChangeAction implements Action {
 
         if (obj instanceof Encoder) {
             this.initialCount = obj.getOutputPortCount().getValue();
-            this.inputPortAction  = new InputPortChangeAction(obj, initial, Math.pow(2, target));
+            this.inputPortAction  = new InputPortChangeAction(obj, obj.getInputPortCount().getValue(), Math.pow(2, target));
             this.outputPortAction = new OutputPortChangeAction(obj, initial, target);
         } else {
             this.initialCount = obj.getInputPortCount().getValue();
             this.inputPortAction  = new InputPortChangeAction(obj, initial, target);
-            this.outputPortAction = new OutputPortChangeAction(obj, initial, Math.pow(2, target));
+            this.outputPortAction = new OutputPortChangeAction(obj, obj.getOutputPortCount().getValue(), Math.pow(2, target));
         }
     }
 
@@ -50,7 +50,6 @@ export class CoderPortChangeAction implements Action {
     public undo(): Action {
         // Change size back first
         this.changeSize(this.initialCount);
-
         this.outputPortAction.undo();
         this.inputPortAction.undo();
         return this;

--- a/src/site/pages/digital/src/containers/SelectionPopup/modules/SegmentCountModule.tsx
+++ b/src/site/pages/digital/src/containers/SelectionPopup/modules/SegmentCountModule.tsx
@@ -1,6 +1,6 @@
 import {GroupAction} from "core/actions/GroupAction";
 import {InputPortChangeAction} from "digital/actions/ports/InputPortChangeAction";
-import {SegmentDisplay} from "digital/models/ioobjects";
+import {SegmentDisplay, BCDDisplay} from "digital/models/ioobjects";
 import {CreateModule, ModuleConfig, PopupModule} from "shared/containers/SelectionPopup/modules/Module";
 
 
@@ -8,7 +8,16 @@ const Config: ModuleConfig<[SegmentDisplay], number> = {
     types: [SegmentDisplay],
     valType: "int",
     getProps: (o) => o.getSegmentCount(),
-    getAction: (s, newCount) => new GroupAction(s.map(o => new InputPortChangeAction(o, o.getInputPortCount().getValue(), newCount)))
+    getAction: (s, newCount) => (
+        new GroupAction(
+            s.map(o => {
+                if (o instanceof BCDDisplay)
+                    return new InputPortChangeAction(o, o.getSegmentCount(), newCount);
+                else
+                    return new InputPortChangeAction(o, o.getInputPortCount().getValue(), newCount);
+            })
+        )
+    )
 }
 
 export const SegmentCountModule = PopupModule({

--- a/src/site/pages/digital/src/containers/SelectionPopup/modules/SegmentCountModule.tsx
+++ b/src/site/pages/digital/src/containers/SelectionPopup/modules/SegmentCountModule.tsx
@@ -1,6 +1,6 @@
 import {GroupAction} from "core/actions/GroupAction";
 import {InputPortChangeAction} from "digital/actions/ports/InputPortChangeAction";
-import {SegmentDisplay, BCDDisplay} from "digital/models/ioobjects";
+import {SegmentDisplay} from "digital/models/ioobjects";
 import {CreateModule, ModuleConfig, PopupModule} from "shared/containers/SelectionPopup/modules/Module";
 
 
@@ -8,16 +8,7 @@ const Config: ModuleConfig<[SegmentDisplay], number> = {
     types: [SegmentDisplay],
     valType: "int",
     getProps: (o) => o.getSegmentCount(),
-    getAction: (s, newCount) => (
-        new GroupAction(
-            s.map(o => {
-                if (o instanceof BCDDisplay)
-                    return new InputPortChangeAction(o, o.getSegmentCount(), newCount);
-                else
-                    return new InputPortChangeAction(o, o.getInputPortCount().getValue(), newCount);
-            })
-        )
-    )
+    getAction: (s, newCount) => new GroupAction(s.map(o => new InputPortChangeAction(o, o.getSegmentCount(), newCount)))
 }
 
 export const SegmentCountModule = PopupModule({


### PR DESCRIPTION
Current Behavior:
After undoing a change of the input/output port count of Encoders/Decoders respectively, Encoders input port count will always change to 2, and Decoders output port count behaves similarly.
After undoing a change of the segment count of BCDDisplay, there is either a crash or a strange rendering bug.
After undoing a change of the segment count of ASCIIDisplay, the segment count always changes to 7.

New Behavior:
Encoder/Decoder I/O count change actions and all SegmentDisplays segment change actions now undo properly, and their port count and segment count return to their previous values, as expected.

Fixes #775 
Fixes #697 