### PR TITLE
Reducing the number of ports can cause an error.

### DIFF
--- a/src/site/shared/containers/SelectionPopup/modules/Module.tsx
+++ b/src/site/shared/containers/SelectionPopup/modules/Module.tsx
@@ -166,7 +166,6 @@ export const CreateModule = (<T extends any[], P extends ModuleTypes>(props: Mod
                 if (tempAction)
                     tempAction.undo();
                 tempAction = config.getAction(selections.get() as T, val).execute();
-                tempAction.execute();
                 render();
             }
 


### PR DESCRIPTION
closes #623 

A gate or component with variable inputs with all its ports filled which then has its number of ports reduced would produce this error in the browser console.
![image](https://user-images.githubusercontent.com/20589728/138537358-3a9f827c-7ac8-4cad-a6e5-87f08121c1c2.png)

This was caused by SlectionPopup modules having the actions they produce executed twice. Its a miracle this hasnt caused more problems :eyes: 