### PR TITLE
Fixed IC Resizing Bounds

### DIFF
--- a/src/app/digital/tools/ICResizeTool.ts
+++ b/src/app/digital/tools/ICResizeTool.ts
@@ -24,8 +24,8 @@ export const ICResizeTool = (() => {
             return "none";
 
         // Determine if mouse is over horizontal or vertical edge
-        return (worldMousePos.y < ic.getPos().y + ic.getSize().y/2 - 4 &&
-                worldMousePos.y > ic.getPos().y - ic.getSize().y/2 + 4) ? "horizontal" : "vertical";
+        return (worldMousePos.y < ic.getPos().y + ic.getSize().y/2 - DEFAULT_BORDER_WIDTH*5/2 &&
+                worldMousePos.y > ic.getPos().y - ic.getSize().y/2 + DEFAULT_BORDER_WIDTH*5/2) ? "horizontal" : "vertical";
     }
 
     return {


### PR DESCRIPTION
Current Behavior:
When Resizing ICs, the bounds for horizontal and vertical resizing weren't established properly, and you can resize horizontally when clicking on the top or bottom border while attempting to resize vertically.

New Behavior:
The bounds have been defined properly, referring to the CONSTANT_BORDER_WIDTH constant. The dimension being resized properly correlates with which border of the IC is being dragged.

Fixes #643 