### PR TITLE
Stop web page swipe navigation on Chrome and Firefox

### DIFF
--- a/src/site/pages/digital/src/containers/App/index.scss
+++ b/src/site/pages/digital/src/containers/App/index.scss
@@ -20,6 +20,7 @@
 body {
     color: #fff;
     background-color: #ccc;
+    overscroll-behavior-x: none;
 }
 
 .white {


### PR DESCRIPTION
closes #844 
This only applies to chrome and firefox, safari on both Mac and iOS does not yet support this css property and requires some sort of javascript hack.