### PR TITLE
Easier Coloring of Split Wires

### DIFF
--- a/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
+++ b/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
@@ -7,27 +7,16 @@ import {IOObject, Port} from "core/models";
 import {CreateModule, ModuleConfig, PopupModule} from "shared/containers/SelectionPopup/modules/Module";
 import { UndoHandler } from "core/tools/handlers/UndoHandler";
 
-
 const Config: ModuleConfig<[LED, Label, Wire], string> = {
     types: [LED, Label, Wire],
     valType: "string",
-    
     isActive: (selections) => {
-        
-        // make sure that this is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes
-        if(selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire )) &&
-           !selections.all((s) => isNode(s))){
-          return true;
-          }
-        else{
-            return false;
-        }
-    },
-    
-     
+    // Make sure that this is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes
+    return (selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire)) &&
+        !selections.all((s) => isNode(s)));
+        },
     getProps: (o) => (isNode(o) ? undefined : o.getColor()),
     getAction: (s, newCol) => new GroupAction(s.filter(o => !isNode(o)).map(o => new ColorChangeAction(o, newCol)))
-
 }
 
 export const ColorModule = PopupModule({

--- a/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
+++ b/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
@@ -4,8 +4,9 @@ import {Label, LED} from "digital/models/ioobjects";
 import {Wire} from "core/models/Wire";
 import {Node, isNode} from "core/models/Node";
 import {IOObject, Port} from "core/models";
+import {UndoHandler} from "core/tools/handlers/UndoHandler";
 import {CreateModule, ModuleConfig, PopupModule} from "shared/containers/SelectionPopup/modules/Module";
-import { UndoHandler } from "core/tools/handlers/UndoHandler";
+
 
 const Config: ModuleConfig<[LED, Label, Wire], string> = {
     types: [LED, Label, Wire],
@@ -13,8 +14,8 @@ const Config: ModuleConfig<[LED, Label, Wire], string> = {
     isActive: (selections) => {
     // Make sure that this is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes
     return (selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire)) &&
-        !selections.all((s) => isNode(s)));
-        },
+    !selections.all((s) => isNode(s))); 
+    },
     getProps: (o) => (isNode(o) ? undefined : o.getColor()),
     getAction: (s, newCol) => new GroupAction(s.filter(o => !isNode(o)).map(o => new ColorChangeAction(o, newCol)))
 }

--- a/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
+++ b/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
@@ -2,14 +2,32 @@ import {GroupAction} from "core/actions/GroupAction";
 import {ColorChangeAction} from "digital/actions/ColorChangeAction";
 import {Label, LED} from "digital/models/ioobjects";
 import {Wire} from "core/models/Wire";
+import {Node, isNode} from "core/models/Node";
+import {IOObject, Port} from "core/models";
 import {CreateModule, ModuleConfig, PopupModule} from "shared/containers/SelectionPopup/modules/Module";
+import { UndoHandler } from "core/tools/handlers/UndoHandler";
 
 
 const Config: ModuleConfig<[LED, Label, Wire], string> = {
     types: [LED, Label, Wire],
     valType: "string",
-    getProps: (o) => o.getColor(),
-    getAction: (s, newCol) => new GroupAction(s.map(o => new ColorChangeAction(o, newCol)))
+    
+    isActive: (selections) => {
+        
+        // make sure that this is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes
+        if(selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire )) &&
+           !selections.all((s) => isNode(s))){
+          return true;
+          }
+        else{
+            return false;
+        }
+    },
+    
+     
+    getProps: (o) => (isNode(o) ? undefined : o.getColor()),
+    getAction: (s, newCol) => new GroupAction(s.filter(o => !isNode(o)).map(o => new ColorChangeAction(o, newCol)))
+
 }
 
 export const ColorModule = PopupModule({

--- a/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
+++ b/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
@@ -12,8 +12,9 @@ const Config: ModuleConfig<[LED, Label, Wire], string> = {
     types: [LED, Label, Wire],
     valType: "string",
     isActive: (selections) => {
-    // Make sure that this is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes
-    return (selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire)) && !selections.all((s) => isNode(s))); 
+        // Make sure that this is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes
+        return selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire)) &&  
+               !selections.all((s) => isNode(s)); 
     },
     getProps: (o) => (isNode(o) ? undefined : o.getColor()),
     getAction: (s, newCol) => new GroupAction(s.filter(o => !isNode(o)).map(o => new ColorChangeAction(o, newCol)))

--- a/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
+++ b/src/site/pages/digital/src/containers/SelectionPopup/modules/ColorModule.tsx
@@ -13,8 +13,7 @@ const Config: ModuleConfig<[LED, Label, Wire], string> = {
     valType: "string",
     isActive: (selections) => {
     // Make sure that this is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes
-    return (selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire)) &&
-    !selections.all((s) => isNode(s))); 
+    return (selections.all((s) => (isNode(s) || s instanceof LED || s instanceof Label || s instanceof Wire)) && !selections.all((s) => isNode(s))); 
     },
     getProps: (o) => (isNode(o) ? undefined : o.getColor()),
     getAction: (s, newCol) => new GroupAction(s.filter(o => !isNode(o)).map(o => new ColorChangeAction(o, newCol)))

--- a/src/site/shared/containers/SelectionPopup/modules/Module.tsx
+++ b/src/site/shared/containers/SelectionPopup/modules/Module.tsx
@@ -11,6 +11,7 @@ export type ModuleTypes = number | string;
 export type ModuleConfig<T extends any[], P extends ModuleTypes> = {
     types: (Function & {prototype: T[number]})[];
     valType: "float" | "int" | "string";
+    isActive?: (selections: SelectionsWrapper) => boolean;
     getProps: (o: T[number]) => P;
     getAction: (s: (T[number])[], newVal: P) => Action;
     getDisplayVal?: (val: P) => string | number;
@@ -131,8 +132,11 @@ export const CreateModule = (<T extends any[], P extends ModuleTypes>(props: Mod
             }
 
             // Make sure all selections are exactly of types:
-            const active = config.types.reduce((enabled, Type) =>
-                enabled || (selections.get().filter(s => s instanceof Type).length === selections.amount()),
+            const active = config.isActive ? 
+                config.isActive(selections) : 
+                config.types.reduce(
+                    (enabled, Type) => enabled || (selections.get().filter(s => s instanceof Type).length === selections.amount()
+                ),
             false);
             if (!active) {
                 setState({active: false});
@@ -141,7 +145,7 @@ export const CreateModule = (<T extends any[], P extends ModuleTypes>(props: Mod
 
             const comps = selections.get() as T;
 
-            const counts = comps.map(s => config.getProps(s));
+            const counts = comps.map(s => config.getProps(s)).filter(Boolean);
 
             same = counts.every(c => (c === counts[0]));
             val = counts[0];


### PR DESCRIPTION
Fixes #784. Added an active property to the ColorModule.tsx which makes sure that the color is only active if all the types are LED/Label/Wire/Node, but not ONLY Nodes. If it’s just a Node then it doesn’t apply otherwise the color module pops up and applies to all the wires. 
