### PR TITLE
Added code coverage commands

### DIFF
--- a/docs/GettingStarted/Running.md
+++ b/docs/GettingStarted/Running.md
@@ -49,14 +49,9 @@ To test OpenCircuits locally, simply run
 yarn test
 ```
 
-To view the coverage of tests on files you changed, run
+To view the coverage of all tests, run
 ```bash
 yarn coverage
-```
-
-To view coverage of tests on all files, run
-```bash
-yarn coverage:all
 ```
 
 ---

--- a/docs/GettingStarted/Running.md
+++ b/docs/GettingStarted/Running.md
@@ -49,6 +49,16 @@ To test OpenCircuits locally, simply run
 yarn test
 ```
 
+To view the coverage of tests on files you changed, run
+```bash
+yarn coverage
+```
+
+To view coverage of tests on all files, run
+```bash
+yarn coverage:all
+```
+
 ---
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "docs": "cd ./src/site/pages/docs && yarn start",
     "build:docs": "cd ./src/site/pages/docs && yarn build",
     "build:jsdocs": "ts-node ./scripts/docs/index.ts",
-    "test": "node ./scripts/test.js"
+    "test": "node ./scripts/test.js",
+    "coverage": "node ./scripts/test.js --coverage",
+    "coverage:all": "node ./scripts/test.js --coverage --watchAll"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "build:docs": "cd ./src/site/pages/docs && yarn build",
     "build:jsdocs": "ts-node ./scripts/docs/index.ts",
     "test": "node ./scripts/test.js",
-    "coverage": "node ./scripts/test.js --coverage",
-    "coverage:all": "node ./scripts/test.js --coverage --watchAll"
+    "coverage": "node ./scripts/test.js --coverage"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -18,8 +18,6 @@ const DIRS = getDirs(true, true);
 const DIR_MAP = Object.fromEntries(DIRS.map(d => [d.value, d]));
 
 async function launch_test(dir, flags) {
-    if (flags.coverage)
-        open(flags.coverageDirectory + "/lcov-report/index.html");
     return await jest.runCLI({
         ...flags,
         config: JSON.stringify({
@@ -36,12 +34,10 @@ async function launch_test(dir, flags) {
     const argv = yargs(process.argv.slice(2))
         .boolean("ci")
         .boolean("coverage")
-        .boolean("watchAll")
         .argv;
 
     const ci = argv.ci;
     const coverage = argv.coverage;
-    const watchAll = argv.watchAll;
 
     let dirs = argv._;
     if (ci && dirs.length === 0) {
@@ -61,9 +57,10 @@ async function launch_test(dir, flags) {
     }
 
     const flags = {
-        ci, watch: (dirs.length === 1 && !ci),
+        ci: (dirs.length === 1 && !ci),
+        watch: (dirs.length === 1 && !ci) && !coverage,
         coverage: coverage,
-        watchAll: watchAll
+        collectCoverageFrom: "**/*.{js,ts,tsx}"
     };
 
     const results = [];
@@ -89,6 +86,8 @@ async function launch_test(dir, flags) {
         results.push(
             (await launch_test(testDir, flags)).results
         );
+        if (coverage)
+            open(flags.coverageDirectory + "/lcov-report/index.html");
     }
 
     const pass = results.every(r => r.success);

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -32,9 +32,13 @@ async function launch_test(dir, flags) {
 (async () => {
     const argv = yargs(process.argv.slice(2))
         .boolean("ci")
+        .boolean("coverage")
+        .boolean("watchAll")
         .argv;
 
     const ci = argv.ci;
+    const coverage = argv.coverage;
+    const watchAll = argv.watchAll;
 
     let dirs = argv._;
     if (ci && dirs.length === 0) {
@@ -54,7 +58,9 @@ async function launch_test(dir, flags) {
     }
 
     const flags = {
-        ci, watch: (dirs.length === 1 && !ci)
+        ci, watch: (dirs.length === 1 && !ci),
+        coverage: coverage,
+        watchAll: watchAll
     };
 
     const results = [];

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -57,9 +57,9 @@ async function launch_test(dir, flags) {
     }
 
     const flags = {
-        ci: (dirs.length === 1 && !ci),
+        ci,
         watch: (dirs.length === 1 && !ci) && !coverage,
-        coverage: coverage,
+        coverage,
         collectCoverageFrom: "**/*.{js,ts,tsx}"
     };
 

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -6,6 +6,7 @@ const getEnv = require("./utils/env");
 const getDirs = require("./utils/getDirs");
 const getAliases = require("./utils/getAliases");
 const path = require("path");
+const open = require("open");
 
 
 // Do this as the first thing so that any code reading it knows the right env.
@@ -17,6 +18,8 @@ const DIRS = getDirs(true, true);
 const DIR_MAP = Object.fromEntries(DIRS.map(d => [d.value, d]));
 
 async function launch_test(dir, flags) {
+    if (flags.coverage)
+        open(flags.coverageDirectory + "/lcov-report/index.html");
     return await jest.runCLI({
         ...flags,
         config: JSON.stringify({
@@ -81,8 +84,10 @@ async function launch_test(dir, flags) {
             console.log(chalk.yellow("Skipping disabled directory,", chalk.underline(dir)));
             continue;
         }
+        const testDir = dir === "app" ? "src/app" : `src/site/pages/${dir}`;
+        flags.coverageDirectory = `${process.cwd()}/coverage/${testDir}`;
         results.push(
-            (await launch_test(dir === "app" ? "src/app" : `src/site/pages/${dir}`, flags)).results
+            (await launch_test(testDir, flags)).results
         );
     }
 


### PR DESCRIPTION
Added `yarn coverage` and `yarn coverage:all` commands, including corresponding documentation for an explanation of their use.
closes #918