### PR TITLE
Specify NPM install version

### DIFF
--- a/docs/GettingStarted/Installation.mdx
+++ b/docs/GettingStarted/Installation.mdx
@@ -42,7 +42,7 @@ We have yet to find a working solution with WSL, but please feel free to let us 
 
 #### NPM
 
-[Install the latest version of npm here](https://nodejs.org/en/) and make sure it works by typing `npm --version` in the command prompt.
+[Install the LTS version of npm here](https://nodejs.org/en/) and make sure it works by typing `npm --version` in the command prompt.
 
 (Note: after installing it make sure to restart command prompt so that the command gets recognized)
 


### PR DESCRIPTION
Updated Windows text specify that contributors should install the LTS version of NPM instead of the latest version