### PR TITLE
Changed header link

### DIFF
--- a/src/site/shared/containers/Header/index.tsx
+++ b/src/site/shared/containers/Header/index.tsx
@@ -21,7 +21,7 @@ export const Header = ({ img, helpers, info, extraUtilities }: Props) => (
         <HeaderLeft helpers={helpers} />
 
         <div className="header__center">
-            <a href="/home" target="_blank">
+            <a href="/" target="_blank">
                 <img className="header__center__logo" src={img} height="100%" alt="OpenCircuits logo" />
             </a>
             <a href="https://github.com/OpenCircuits/OpenCircuits/" rel="noreferrer" target="_blank">


### PR DESCRIPTION
The header currently links to the home page which doesn't exist. The header now links to opencircuits.io, refreshing the page when you click it. 

Fixes #981 