### PR TITLE
Copy from component popup

### DIFF
--- a/src/app/core/tools/handlers/CopyHandler.ts
+++ b/src/app/core/tools/handlers/CopyHandler.ts
@@ -14,7 +14,14 @@ import {EventHandler} from "../EventHandler";
 export const CopyHandler: EventHandler = ({
     conditions: (event: Event, {selections}: CircuitInfo) =>
         ((event.type === "copy" || event.type === "cut") &&
-         selections.amount() > 0),
+         selections.amount() > 0) &&
+        // If a label element is not selected, 
+        // or if an editable component is selected but it is a "Caret" (cursor) instead of highlighted text,
+        // then copy the component
+        // Otherwise there is text selected, so do default copying
+        // Necessary to fix #874
+        (document.getSelection()?.anchorNode?.nodeName !== "LABEL" || 
+         document.getSelection()?.type === "Caret"),
 
     getResponse: ({selections, designer, history}: CircuitInfo, {type, ev}: CopyPasteEvent) => {
         const objs = selections.get().filter(o => o instanceof IOObject) as IOObject[];
@@ -27,16 +34,8 @@ export const CopyHandler: EventHandler = ({
         // We don't copy the data from the json since it will cause 
         // some weird error, which will cause the issue #746
         ev.clipboardData.setData("text/plain", str);
-
-        // If an editable component (LABEL) is not selected, 
-        // or if an editable component is selected but it is a "Caret" (cursor) instead of highlighted text,
-        // then copy the component
-        // Otherwise there is text selected, so do default copying
-        // Necessary to fix #874
-        if (document.getSelection()?.anchorNode?.nodeName !== "LABEL" || document.getSelection()?.type === "Caret") {
-            ev.preventDefault(); // Necessary to copy correctly
-        }
-
+        ev.preventDefault(); // Necessary to copy correctly
+        
         if (type === "cut") {
             // Delete selections
             history.add(new GroupAction([

--- a/src/app/core/tools/handlers/CopyHandler.ts
+++ b/src/app/core/tools/handlers/CopyHandler.ts
@@ -28,9 +28,12 @@ export const CopyHandler: EventHandler = ({
         // some weird error, which will cause the issue #746
         ev.clipboardData.setData("text/plain", str);
 
-        // If no text is selected, copy the component
-        // Otherwise, do default copying
-        if (document.getSelection()?.anchorNode?.nodeName != 'LABEL' || document.getSelection()?.type == "Caret") {
+        // If an editable component (LABEL) is not selected, 
+        // or if an editable component is selected but it is a "Caret" (cursor) instead of highlighted text,
+        // then copy the component
+        // Otherwise there is text selected, so do default copying
+        // Necessary to fix #874
+        if (document.getSelection()?.anchorNode?.nodeName !== "LABEL" || document.getSelection()?.type === "Caret") {
             ev.preventDefault(); // Necessary to copy correctly
         }
 

--- a/src/app/core/tools/handlers/CopyHandler.ts
+++ b/src/app/core/tools/handlers/CopyHandler.ts
@@ -35,7 +35,7 @@ export const CopyHandler: EventHandler = ({
         // some weird error, which will cause the issue #746
         ev.clipboardData.setData("text/plain", str);
         ev.preventDefault(); // Necessary to copy correctly
-        
+
         if (type === "cut") {
             // Delete selections
             history.add(new GroupAction([

--- a/src/app/core/tools/handlers/CopyHandler.ts
+++ b/src/app/core/tools/handlers/CopyHandler.ts
@@ -27,7 +27,12 @@ export const CopyHandler: EventHandler = ({
         // We don't copy the data from the json since it will cause 
         // some weird error, which will cause the issue #746
         ev.clipboardData.setData("text/plain", str);
-        ev.preventDefault(); // Necessary to copy correctly
+
+        // If a label box (and no text in it) is selected, copy the component
+        // Otherwise, do default copying
+        if (document.getSelection()?.anchorNode?.nodeName != 'LABEL' || document.getSelection()?.type == "Caret") {
+            ev.preventDefault(); // Necessary to copy correctly
+        }
 
         if (type === "cut") {
             // Delete selections

--- a/src/app/core/tools/handlers/CopyHandler.ts
+++ b/src/app/core/tools/handlers/CopyHandler.ts
@@ -28,7 +28,7 @@ export const CopyHandler: EventHandler = ({
         // some weird error, which will cause the issue #746
         ev.clipboardData.setData("text/plain", str);
 
-        // If a label box (and no text in it) is selected, copy the component
+        // If no text is selected, copy the component
         // Otherwise, do default copying
         if (document.getSelection()?.anchorNode?.nodeName != 'LABEL' || document.getSelection()?.type == "Caret") {
             ev.preventDefault(); // Necessary to copy correctly


### PR DESCRIPTION
Resolves #874

If any text is selected within a component's popup, it will copy the text instead of the entire component as it did previously.
If the cursor is in the text field but nothing is selected, it will copy the component. I thought this made the most sense, but that can be changed easily if not.
