### PR TITLE
Allow optional disabling of snapping when using the Translate Action

### DIFF
--- a/src/app/core/actions/transform/TranslateAction.ts
+++ b/src/app/core/actions/transform/TranslateAction.ts
@@ -28,6 +28,8 @@ export class TranslateAction implements Action {
      */
     protected targetPositions: Vector[];
 
+    protected snap: boolean;
+
     /**
      * Creates a translation of component(s) from one position to another.
      * Each component in objs list has corresponding initial position and target position in those
@@ -37,11 +39,13 @@ export class TranslateAction implements Action {
      * @param initialPositions Initializes the array with the selected components' starting positions
      * @param targetPositions Initializes the array with the selected components' final positions
      */
-    public constructor(objs: Component[], initialPositions: Vector[], targetPositions: Vector[]) {
+    public constructor(objs: Component[], initialPositions: Vector[], targetPositions: Vector[], snap?: boolean) {
         this.objs = objs;
 
         this.initialPositions = initialPositions;
         this.targetPositions = targetPositions;
+        if(typeof snap === "undefined"){ this.snap = true; }
+        else{ this.snap = snap;}
     }
 
     /**
@@ -53,7 +57,9 @@ export class TranslateAction implements Action {
         this.objs.forEach((o, i) => o.setPos(this.targetPositions[i]));
 
         // Always snap afterwards to avoid issue #417
-        this.objs.forEach(o => SnapPos(o));
+        if(this.snap){
+            this.objs.forEach(o => SnapPos(o));
+        }
 
         return this;
     }
@@ -67,7 +73,9 @@ export class TranslateAction implements Action {
         this.objs.forEach((o, i) => o.setPos(this.initialPositions[i]));
 
         // Always snap afterwards to avoid issue #417
-        this.objs.forEach(o => SnapPos(o));
+        if(this.snap){
+            this.objs.forEach(o => SnapPos(o));
+        }
 
         return this;
     }

--- a/src/app/core/actions/transform/TranslateAction.ts
+++ b/src/app/core/actions/transform/TranslateAction.ts
@@ -9,8 +9,7 @@ import {SnapPos} from "./SnapUtils";
 
 /**
  * Translate can be applied to single components or groups of components,
- * used for moving componets from one position to another.* used for moving
- * componets from one position to another.
+ * used for moving componets from one position to another.
  */
 export class TranslateAction implements Action {
     

--- a/src/app/core/actions/transform/TranslateAction.ts
+++ b/src/app/core/actions/transform/TranslateAction.ts
@@ -9,7 +9,8 @@ import {SnapPos} from "./SnapUtils";
 
 /**
  * Translate can be applied to single components or groups of components,
- * used for moving componets from one position to another.
+ * used for moving componets from one position to another.* used for moving
+ * componets from one position to another.
  */
 export class TranslateAction implements Action {
     
@@ -39,13 +40,12 @@ export class TranslateAction implements Action {
      * @param initialPositions Initializes the array with the selected components' starting positions
      * @param targetPositions Initializes the array with the selected components' final positions
      */
-    public constructor(objs: Component[], initialPositions: Vector[], targetPositions: Vector[], snap?: boolean) {
+    public constructor(objs: Component[], initialPositions: Vector[], targetPositions: Vector[], snap = true) {
         this.objs = objs;
 
         this.initialPositions = initialPositions;
         this.targetPositions = targetPositions;
-        if(typeof snap === "undefined"){ this.snap = true; }
-        else{ this.snap = snap;}
+        this.snap = snap;
     }
 
     /**
@@ -57,9 +57,8 @@ export class TranslateAction implements Action {
         this.objs.forEach((o, i) => o.setPos(this.targetPositions[i]));
 
         // Always snap afterwards to avoid issue #417
-        if(this.snap){
+        if(this.snap)
             this.objs.forEach(o => SnapPos(o));
-        }
 
         return this;
     }
@@ -73,9 +72,8 @@ export class TranslateAction implements Action {
         this.objs.forEach((o, i) => o.setPos(this.initialPositions[i]));
 
         // Always snap afterwards to avoid issue #417
-        if(this.snap){
+        if(this.snap)
             this.objs.forEach(o => SnapPos(o));
-        }
 
         return this;
     }

--- a/src/app/core/actions/transform/TranslateAction.ts
+++ b/src/app/core/actions/transform/TranslateAction.ts
@@ -28,6 +28,10 @@ export class TranslateAction implements Action {
      */
     protected targetPositions: Vector[];
 
+    /**
+     * Flag that represents whether or not positions should be snapped.
+     * Necessary to resolve issue #910
+     */
     protected snap: boolean;
 
     /**
@@ -38,6 +42,7 @@ export class TranslateAction implements Action {
      * @param objs Initializes the array with the selected component(s)
      * @param initialPositions Initializes the array with the selected components' starting positions
      * @param targetPositions Initializes the array with the selected components' final positions
+     * @param snap Sets whether or not components will snap. Defaults to true.
      */
     public constructor(objs: Component[], initialPositions: Vector[], targetPositions: Vector[], snap = true) {
         this.objs = objs;
@@ -56,7 +61,7 @@ export class TranslateAction implements Action {
         this.objs.forEach((o, i) => o.setPos(this.targetPositions[i]));
 
         // Always snap afterwards to avoid issue #417
-        if(this.snap)
+        if (this.snap)
             this.objs.forEach(o => SnapPos(o));
 
         return this;
@@ -71,7 +76,7 @@ export class TranslateAction implements Action {
         this.objs.forEach((o, i) => o.setPos(this.initialPositions[i]));
 
         // Always snap afterwards to avoid issue #417
-        if(this.snap)
+        if (this.snap)
             this.objs.forEach(o => SnapPos(o));
 
         return this;

--- a/src/app/core/tools/TranslateTool.ts
+++ b/src/app/core/tools/TranslateTool.ts
@@ -104,8 +104,9 @@ export const TranslateTool: Tool = (() => {
                         curPositions.map(p => Snap(p)):
                         curPositions;
 
+                    const snapping = input.isShiftKeyDown() ? false : true;
                     // Execute translate but don't save to group
-                    new TranslateAction(components, initalPositions, newPositions).execute();
+                    new TranslateAction(components, initalPositions, newPositions, snapping).execute();
 
                     return true;
 

--- a/src/app/core/tools/TranslateTool.ts
+++ b/src/app/core/tools/TranslateTool.ts
@@ -104,9 +104,9 @@ export const TranslateTool: Tool = (() => {
                         curPositions.map(p => Snap(p)):
                         curPositions;
 
-                    const snapping = input.isShiftKeyDown() ? false : true;
+                    const snapToConnections = input.isShiftKeyDown() ? false : true;
                     // Execute translate but don't save to group
-                    new TranslateAction(components, initalPositions, newPositions, snapping).execute();
+                    new TranslateAction(components, initalPositions, newPositions, snapToConnections).execute();
 
                     return true;
 

--- a/src/site/shared/containers/SelectionPopup/modules/PositionModule.tsx
+++ b/src/site/shared/containers/SelectionPopup/modules/PositionModule.tsx
@@ -34,13 +34,13 @@ export const PositionModule = PopupModule({
             inputType: "number",
             config: XConfig,
             step: 1,
-            alt: "X-Position of object(s)"
+            alt: "X-Position of object(s)",
         }),
         CreateModule({
             inputType: "number",
             config: YConfig,
             step: 1,
-            alt: "Y-Position of object(s)"
-        })
-    ]
+            alt: "Y-Position of object(s)",
+        }),
+    ],
 });

--- a/src/site/shared/containers/SelectionPopup/modules/PositionModule.tsx
+++ b/src/site/shared/containers/SelectionPopup/modules/PositionModule.tsx
@@ -12,7 +12,8 @@ const XConfig: ModuleConfig<[Component], number> = {
     getProps: (o) => o.getPos().x/100,
     getAction: (s, newX) => new TranslateAction(s,
                                                 s.map(s => s.getPos()),
-                                                s.map(s => V(newX*100, s.getPos().y))),
+                                                s.map(s => V(newX*100, s.getPos().y)),
+                                                false),
     getDisplayVal: (v) => parseFloat(v.toFixed(2)),
 }
 const YConfig: ModuleConfig<[Component], number> = {
@@ -21,7 +22,8 @@ const YConfig: ModuleConfig<[Component], number> = {
     getProps: (o) => o.getPos().y/100,
     getAction: (s, newY) => new TranslateAction(s,
                                                 s.map(s => s.getPos()),
-                                                s.map(s => V(s.getPos().x, newY*100))),
+                                                s.map(s => V(s.getPos().x, newY*100)),
+                                                false),
     getDisplayVal: (v) => parseFloat(v.toFixed(2)),
 }
 


### PR DESCRIPTION
Fixes #910
I added an optional "snap" flag to the constructor of the Translate Action. All of the snapping calls are ignored when this is set to false. 
This addresses the issue in #910 by setting the translate constructors snap flag to false in the postion module of the selection pop up. This prevents snapping when making minute adjustments to position in the selection pop up. 

Additionaly fixed some minor linting issues.