### PR TITLE
Added Encoder and Decoder Labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "dependencies": {}
 }

--- a/src/app/digital/actions/ports/CoderPortChangeAction.ts
+++ b/src/app/digital/actions/ports/CoderPortChangeAction.ts
@@ -53,10 +53,7 @@ export class CoderPortChangeAction implements Action {
      * @param val refers to the target number chosen by the user.
      */
     protected changeSize(val: number): void {
-        let mul: number = 1;
-        if(val >= 5) mul = 1.2;
-        if(val == 8) mul = 1.4;
-        this.obj.setSize(V(DEFAULT_SIZE * mul, DEFAULT_SIZE/2 * Math.pow(2, val)));
+        this.obj.setSize(V(DEFAULT_SIZE * (1 + (val - 1)/20), DEFAULT_SIZE/2 * Math.pow(2, val)));
     }
     
     /**

--- a/src/app/digital/actions/ports/CoderPortChangeAction.ts
+++ b/src/app/digital/actions/ports/CoderPortChangeAction.ts
@@ -53,7 +53,10 @@ export class CoderPortChangeAction implements Action {
      * @param val refers to the target number chosen by the user.
      */
     protected changeSize(val: number): void {
-        this.obj.setSize(V(DEFAULT_SIZE, DEFAULT_SIZE/2 * Math.pow(2, val)));
+        let mul: number = 1;
+        if(val >= 5) mul = 1.2;
+        if(val == 8) mul = 1.4;
+        this.obj.setSize(V(DEFAULT_SIZE * mul, DEFAULT_SIZE/2 * Math.pow(2, val)));
     }
     
     /**

--- a/src/app/digital/actions/ports/CoderPortChangeAction.ts
+++ b/src/app/digital/actions/ports/CoderPortChangeAction.ts
@@ -67,6 +67,7 @@ export class CoderPortChangeAction implements Action {
 
         this.inputPortAction.execute();
         this.outputPortAction.execute();
+        this.obj.updatePortNames();
         return this;
     }
     
@@ -81,6 +82,7 @@ export class CoderPortChangeAction implements Action {
 
         this.outputPortAction.undo();
         this.inputPortAction.undo();
+        this.obj.updatePortNames();
         return this;
     }
 

--- a/src/app/digital/models/ioobjects/other/Decoder.ts
+++ b/src/app/digital/models/ioobjects/other/Decoder.ts
@@ -22,6 +22,8 @@ export class Decoder extends DigitalComponent {
 
         // activate 0th port for initial state
         super.activate(true, 0);
+
+        this.updatePortNames();
     }
 
     public activate(): void {
@@ -34,6 +36,15 @@ export class Decoder extends DigitalComponent {
         this.getOutputPorts().forEach((_, i) => {
             super.activate(i === num, i);
         });
+    }
+
+    protected updatePortNames(): void {
+        this.inputs.getPorts().forEach((p, i) => {
+            if (p.getName() == "") p.setName(`I${i}`);
+        })
+        this.outputs.getPorts().forEach((p, i) => {
+            if (p.getName() == "") p.setName(`O${i}`);
+        })
     }
 
     public getDisplayName(): string {

--- a/src/app/digital/models/ioobjects/other/Decoder.ts
+++ b/src/app/digital/models/ioobjects/other/Decoder.ts
@@ -38,7 +38,7 @@ export class Decoder extends DigitalComponent {
         });
     }
 
-    protected updatePortNames(): void {
+    public updatePortNames(): void {
         this.inputs.getPorts().forEach((p, i) => {
             if (p.getName() == "") p.setName(`I${i}`);
         })

--- a/src/app/digital/models/ioobjects/other/Decoder.ts
+++ b/src/app/digital/models/ioobjects/other/Decoder.ts
@@ -40,11 +40,11 @@ export class Decoder extends DigitalComponent {
 
     public updatePortNames(): void {
         this.inputs.getPorts().forEach((p, i) => {
-            if (p.getName() == "") p.setName(`I${i}`);
-        })
+            if (p.getName() === "") p.setName(`I${i}`);
+        });
         this.outputs.getPorts().forEach((p, i) => {
-            if (p.getName() == "") p.setName(`O${i}`);
-        })
+            if (p.getName() === "") p.setName(`O${i}`);
+        });
     }
 
     public getDisplayName(): string {

--- a/src/app/digital/models/ioobjects/other/Encoder.ts
+++ b/src/app/digital/models/ioobjects/other/Encoder.ts
@@ -39,7 +39,7 @@ export class Encoder extends DigitalComponent {
         });
     }
 
-    protected updatePortNames(): void {
+    public updatePortNames(): void {
         this.inputs.getPorts().forEach((p, i) => {
             if (p.getName() == "") p.setName(`I${i}`);
         })

--- a/src/app/digital/models/ioobjects/other/Encoder.ts
+++ b/src/app/digital/models/ioobjects/other/Encoder.ts
@@ -41,11 +41,11 @@ export class Encoder extends DigitalComponent {
 
     public updatePortNames(): void {
         this.inputs.getPorts().forEach((p, i) => {
-            if (p.getName() == "") p.setName(`I${i}`);
-        })
+            if (p.getName() === "") p.setName(`I${i}`);
+        });
         this.outputs.getPorts().forEach((p, i) => {
-            if (p.getName() == "") p.setName(`O${i}`);
-        })
+            if (p.getName() === "") p.setName(`O${i}`);
+        });
     }
 
     public getDisplayName(): string {

--- a/src/app/digital/models/ioobjects/other/Encoder.ts
+++ b/src/app/digital/models/ioobjects/other/Encoder.ts
@@ -20,6 +20,7 @@ export class Encoder extends DigitalComponent {
               V(DEFAULT_SIZE, DEFAULT_SIZE*2),
               new ConstantSpacePositioner<InputPort>("left", DEFAULT_SIZE),
               new ConstantSpacePositioner<OutputPort>("right", DEFAULT_SIZE));
+        this.updatePortNames();
     }
 
     public activate(): void {
@@ -36,6 +37,15 @@ export class Encoder extends DigitalComponent {
         bits.forEach((bit, i) => {
             super.activate(bit === "1", i);
         });
+    }
+
+    protected updatePortNames(): void {
+        this.inputs.getPorts().forEach((p, i) => {
+            if (p.getName() == "") p.setName(`I${i}`);
+        })
+        this.outputs.getPorts().forEach((p, i) => {
+            if (p.getName() == "") p.setName(`O${i}`);
+        })
     }
 
     public getDisplayName(): string {


### PR DESCRIPTION
Encoders and Decoders do not have any labels on their ports, so I added an updatePortNames method to both the Encoder and Decoder that is very similar to Mux.

Fixes #989  