### PR TITLE
Fixed bottom of canvas from getting cut off

### DIFF
--- a/src/site/pages/digital/src/containers/MainDesigner/index.tsx
+++ b/src/site/pages/digital/src/containers/MainDesigner/index.tsx
@@ -108,7 +108,7 @@ export const MainDesigner = ({info, canvas}: Props) => {
                    }}>
             <canvas className="main__canvas"
                     width={w}
-                    height={h-HEADER_HEIGHT} />
+                    height={h-HEADER_HEIGHT+4} />
         </Droppable>
     </>);
 }


### PR DESCRIPTION
Added 4 pixels to the bottom of the canvas to keep it from getting cut off. 
Fixes #810 "Bottom of canvas is cut off".
