### PR TITLE
Fixed panning not working when text box selected

### DIFF
--- a/src/app/core/utils/Input.ts
+++ b/src/app/core/utils/Input.ts
@@ -102,7 +102,7 @@ export class Input {
     private hookupKeyboardEvents(): void {
         // Keyboard events
         window.addEventListener("keydown", (e: KeyboardEvent) => {
-            if (!(document.activeElement instanceof HTMLInputElement)) {
+            if (e.key === "Alt" || !(document.activeElement instanceof HTMLInputElement)) {
                 this.onKeyDown(e.key as Key);
 
                 if (this.isPreventedCombination(e.key as Key))
@@ -110,7 +110,7 @@ export class Input {
             }
         }, false);
         window.addEventListener("keyup",   (e: KeyboardEvent) => {
-            if (!(document.activeElement instanceof HTMLInputElement))
+            if (e.key === "Alt" || !(document.activeElement instanceof HTMLInputElement))
                 this.onKeyUp(e.key as Key)
         }, false);
 

--- a/src/app/core/utils/Input.ts
+++ b/src/app/core/utils/Input.ts
@@ -102,6 +102,7 @@ export class Input {
     private hookupKeyboardEvents(): void {
         // Keyboard events
         window.addEventListener("keydown", (e: KeyboardEvent) => {
+            // Check for "Alt" to fix issue #943
             if (e.key === "Alt" || !(document.activeElement instanceof HTMLInputElement)) {
                 this.onKeyDown(e.key as Key);
 
@@ -110,6 +111,7 @@ export class Input {
             }
         }, false);
         window.addEventListener("keyup",   (e: KeyboardEvent) => {
+            // Check for "Alt" to fix issue #943
             if (e.key === "Alt" || !(document.activeElement instanceof HTMLInputElement))
                 this.onKeyUp(e.key as Key)
         }, false);


### PR DESCRIPTION
Added exception for the alt key to disabling keyboard input when an htmlinput element is selected.
Fixes #943 