### PR TITLE
Disable Context Menu Actions if they would do nothing

### DIFF
--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -147,10 +147,10 @@ export const ContextMenu = ({info, paste}: Props) => {
                  top: `${pos?.y + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET}px`,
                  visibility: (isOpen ? "initial" : "hidden")
              }}>
-            <button title="Cut"        onClick={() => doFunc(onCut)}disabled = {selections.amount() === 0}>Cut</button>
-            <button title="Copy"       onClick={() => doFunc(onCopy)}disabled= {selections.amount() === 0}>Copy</button>
+            <button title="Cut"        onClick={() => doFunc(onCut)} disabled={selections.amount() === 0}>Cut</button>
+            <button title="Copy"       onClick={() => doFunc(onCopy)} disabled={selections.amount() === 0}>Copy</button>
             <button title="Paste"      onClick={() => doFunc(onPaste)}>Paste</button>
-            <button title="Select All" onClick={() => doFunc(onSelectAll)} disabled = {designer.getObjects().length === 0}>Select All</button>
+            <button title="Select All" onClick={() => doFunc(onSelectAll)} disabled={designer.getObjects().length === 0}>Select All</button>
             <hr/>
             <button title="Undo" onClick={() => doFunc(onUndo)} disabled={undoHistory.length === 0}>Undo</button>
             <button title="Redo" onClick={() => doFunc(onRedo)} disabled={redoHistory.length === 0}>Redo</button>

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -147,10 +147,10 @@ export const ContextMenu = ({info, paste}: Props) => {
                  top: `${pos?.y + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET}px`,
                  visibility: (isOpen ? "initial" : "hidden")
              }}>
-            <button title="Cut"        onClick={() => doFunc(onCut)}>Cut</button>
-            <button title="Copy"       onClick={() => doFunc(onCopy)}>Copy</button>
+            <button title="Cut"        onClick={() => doFunc(onCut)}disabled = {selections.amount() === 0}>Cut</button>
+            <button title="Copy"       onClick={() => doFunc(onCopy)}disabled= {selections.amount() === 0}>Copy</button>
             <button title="Paste"      onClick={() => doFunc(onPaste)}>Paste</button>
-            <button title="Select All" onClick={() => doFunc(onSelectAll)}>Select All</button>
+            <button title="Select All" onClick={() => doFunc(onSelectAll)} disabled = {designer.getObjects().length === 0}>Select All</button>
             <hr/>
             <button title="Undo" onClick={() => doFunc(onUndo)} disabled={undoHistory.length === 0}>Undo</button>
             <button title="Redo" onClick={() => doFunc(onRedo)} disabled={redoHistory.length === 0}>Redo</button>


### PR DESCRIPTION
Disables the Cut, Copy, and Select All actions in the context menu if doing them doesn't make sense (EX: Copying nothing)

Resolves #991 
