### PR TITLE
Fixed word-wrapping history box issue

### DIFF
--- a/src/site/shared/containers/HistoryBox/index.scss
+++ b/src/site/shared/containers/HistoryBox/index.scss
@@ -83,8 +83,9 @@ $historybox-width: 250px;
     }
 
     &__entry {
-        height: 50px;
-        line-height: 50px;
+        height: auto;
+        line-height: 30px;
+        padding: 10px;
 
         margin: 5px;
         text-align: center;


### PR DESCRIPTION
For actions with long names, the history box entry does not account for word-wrapping on two lines. To fix this, I added padding to the entry, set the height of an entry to auto, and adjusted the line height to fix the large spacing between lines. 

Here is an after photo for the new entry box: 
<img width="187" alt="after-lh30-pad10" src="https://user-images.githubusercontent.com/98288154/154764592-a8785d70-0320-431e-8f1b-dcfec5861576.PNG">

Fixes #973 