### PR TITLE
Add more context buttons

### DIFF
--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -168,10 +168,10 @@ export const ContextMenu = ({info, paste}: Props) => {
                  top: `${pos?.y + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET}px`,
                  visibility: (isOpen ? "initial" : "hidden")
              }}>
-            <button title="Cut"        onClick={() => doFunc(onCut)}disabled = {selections.amount() === 0}>Cut</button>
-            <button title="Copy"       onClick={() => doFunc(onCopy)}disabled= {selections.amount() === 0}>Copy</button>
+            <button title="Cut"        onClick={() => doFunc(onCut)}>Cut</button>
+            <button title="Copy"       onClick={() => doFunc(onCopy)}>Copy</button>
             <button title="Paste"      onClick={() => doFunc(onPaste)}>Paste</button>
-            <button title="Select All" onClick={() => doFunc(onSelectAll)} disabled = {designer.getObjects().length === 0}>Select All</button>
+            <button title="Select All" onClick={() => doFunc(onSelectAll)}>Select All</button>
             <button title="Focus"      onClick={() => doFunc(OnFocus)}>Focus</button>
             <hr/>
             <button title="Undo" onClick={() => doFunc(onUndo)} disabled={undoHistory.length === 0}>Undo</button>

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -1,9 +1,10 @@
 import {useEffect, useRef} from "react";
 import {HEADER_HEIGHT} from "shared/utils/Constants";
-import { FIT_PADDING_RATIO } from "core/utils/Constants";
+import {FIT_PADDING_RATIO} from "core/utils/Constants";
 
 import {CircuitInfo} from "core/utils/CircuitInfo";
 import {SerializeForCopy} from "core/utils/ComponentUtils";
+import {GetCameraFit} from "core/utils/ComponentUtils";
 import {V, Vector} from "core/utils/math/Vector";
 
 import {IOObject} from "core/models";
@@ -12,13 +13,14 @@ import {CullableObject} from "core/models";
 import {GroupAction} from "core/actions/GroupAction";
 import {CreateDeselectAllAction, CreateGroupSelectAction} from "core/actions/selection/SelectAction";
 import {CreateDeleteGroupAction} from "core/actions/deletion/DeleteGroupActionFactory";
+import {MoveCameraAction} from "core/actions/camera/MoveCameraAction";
 
 import {useSharedDispatch, useSharedSelector} from "shared/utils/hooks/useShared";
 import {CloseContextMenu, OpenContextMenu} from "shared/state/ContextMenu";
 import {useHistory} from "shared/utils/hooks/useHistory";
 
-import {GetCameraFit } from "core/utils/ComponentUtils";
-import {MoveCameraAction} from "core/actions/camera/MoveCameraAction";
+
+
 
 import "./index.scss";
 

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -126,7 +126,6 @@ export const ContextMenu = ({info, paste}: Props) => {
     const onRedo = async () => history.redo();
 
 
-
     /* Helper function for buttons to call the function and render/close the popup */
     const doFunc = (func: () => void) => {
         // Don't do anything if locked

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -19,9 +19,6 @@ import {useSharedDispatch, useSharedSelector} from "shared/utils/hooks/useShared
 import {CloseContextMenu, OpenContextMenu} from "shared/state/ContextMenu";
 import {useHistory} from "shared/utils/hooks/useHistory";
 
-
-
-
 import "./index.scss";
 
 

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -130,9 +130,6 @@ export const ContextMenu = ({info, paste}: Props) => {
             designer.getObjects() :
             selections.get().filter(o => o instanceof Component)) as Component[];
 
-        if (components.length === 0)
-            return;
-
         history.add(new GroupAction([
             ...components.map(c =>
                 new RotateAction([c], c.getPos(), [c.getAngle()], [0])
@@ -201,7 +198,7 @@ export const ContextMenu = ({info, paste}: Props) => {
             <button title="Select All" onClick={() => doFunc(onSelectAll)}>Select All</button>
             <hr/>
             <button title="Focus"      onClick={() => doFunc(OnFocus)}>Focus</button>
-            <button title="CleanUp"      onClick={() => doFunc(onCleanUp)}>Clean Up</button>
+            <button title="CleanUp"      onClick={() => doFunc(onCleanUp)}disabled = {designer.getObjects.length === 0}>Clean Up</button>
             <hr/>
             <button title="Undo" onClick={() => doFunc(onUndo)} disabled={undoHistory.length === 0}>Undo</button>
             <button title="Redo" onClick={() => doFunc(onRedo)} disabled={redoHistory.length === 0}>Redo</button>


### PR DESCRIPTION
Added three additional context menu operations using the event handlers. These functions are separated from the other menu operations with a line for clarity.

Resolves: #992 

![image](https://user-images.githubusercontent.com/72285616/155809358-c661fca7-98e3-41c3-9679-db7d9c03c074.png)
