### PR TITLE
Changed BusAction to connect ports by position along an axis

### DIFF
--- a/src/app/digital/actions/addition/BusActionFactory.ts
+++ b/src/app/digital/actions/addition/BusActionFactory.ts
@@ -3,6 +3,9 @@ import {ConnectionAction} from "core/actions/addition/ConnectionAction";
 
 import {InputPort} from "digital/models/ports/InputPort";
 import {OutputPort} from "digital/models/ports/OutputPort";
+import { Port } from "core/models";
+import { GRID_SIZE } from "core/utils/Constants";
+
 
 export function CreateBusAction(outputPorts: OutputPort[], inputPorts: InputPort[]): GroupAction {
     if (inputPorts.length !== outputPorts.length)
@@ -16,38 +19,61 @@ export function CreateBusAction(outputPorts: OutputPort[], inputPorts: InputPort
     if (!designer)
         throw new Error("CreateBusAction failed: Designer not found");
 
-    // Connect closest pairs of input and output ports
-    while (outputPorts.length > 0) {
-        // Find closest pair of input and output ports
-        const max = {dist: -Infinity, in: undefined as InputPort | undefined, out: undefined as OutputPort | undefined};
-        outputPorts.forEach((outPort) => {
 
-            // Find the closest input port
-            const min = {dist: Infinity, in: undefined as InputPort | undefined};
-            inputPorts.forEach((inPort) => {
-                // Calculate distance between target pos of ports
-                const dist = outPort.getWorldTargetPos().distanceTo(inPort.getWorldTargetPos());
-                if (dist < min.dist) {
-                    min.dist = dist;
-                    min.in = inPort;
-                }
-            });
-
-            if (min.dist > max.dist) {
-                max.dist = min.dist;
-                max.in = min.in;
-                max.out = outPort;
-            }
-        });
-
-        // Create action
-        action.add(new ConnectionAction(designer, max.out!, max.in!));
-        // wire.setAsStraight(true); @TODO
-
-        // Remove ports from array
-        inputPorts.splice(inputPorts.indexOf(max.in!), 1);
-        outputPorts.splice(outputPorts.indexOf(max.out!), 1);
+    // Sort inputs/outputs by their position
+    const sortByPos = (a: Port, b: Port) => {
+        const p1 = a.getWorldTargetPos(), p2 = b.getWorldTargetPos();
+        if (Math.abs(p2.y - p1.y) <= .25){ // If same-ish-y, sort by x from LtR
+            return p1.x - p2.x;
+        }
+        return p1.y - p2.y; // Sort by y-pos from Top to Bottom
     }
+
+    inputPorts.sort(sortByPos);
+    outputPorts.sort(sortByPos);
+
+    var currPort:number = 0;
+    for(currPort = 0; currPort < inputPorts.length; currPort++){
+         // Create action
+         action.add(new ConnectionAction(designer, outputPorts[currPort]!, inputPorts[currPort]!));
+         // wire.setAsStraight(true); @TODO
+    }
+
+
+
+
+    // Connect closest pairs of input and output ports
+    // while (outputPorts.length > 0) {
+    //     // Find closest pair of input and output ports
+    //     const max = {dist: -Infinity, in: undefined as InputPort | undefined, out: undefined as OutputPort | undefined};
+    //     outputPorts.forEach((outPort) => {
+
+    //         // Find the closest input port
+    //         const min = {dist: Infinity, in: undefined as InputPort | undefined};
+    //         inputPorts.forEach((inPort) => {
+    //             // Calculate distance between target pos of ports
+    //             const dist = outPort.getWorldTargetPos().distanceTo(inPort.getWorldTargetPos());
+    //             if (dist < min.dist) {
+    //                 min.dist = dist;
+    //                 min.in = inPort;
+    //             }
+    //         });
+
+    //         if (min.dist > max.dist) {
+    //             max.dist = min.dist;
+    //             max.in = min.in;
+    //             max.out = outPort;
+    //         }
+    //     });
+
+    //     // Create action
+    //     action.add(new ConnectionAction(designer, max.out!, max.in!));
+    //     // wire.setAsStraight(true); @TODO
+
+    //     // Remove ports from array
+    //     inputPorts.splice(inputPorts.indexOf(max.in!), 1);
+    //     outputPorts.splice(outputPorts.indexOf(max.out!), 1);
+    // }
 
     return action;
 }

--- a/src/app/digital/actions/addition/BusActionFactory.ts
+++ b/src/app/digital/actions/addition/BusActionFactory.ts
@@ -1,9 +1,9 @@
 import {GroupAction} from "core/actions/GroupAction";
 import {ConnectionAction} from "core/actions/addition/ConnectionAction";
+import {Port} from "core/models";
 
 import {InputPort} from "digital/models/ports/InputPort";
 import {OutputPort} from "digital/models/ports/OutputPort";
-import {Port} from "core/models";
 
 
 export function CreateBusAction(outputPorts: OutputPort[], inputPorts: InputPort[]): GroupAction {

--- a/src/app/digital/actions/addition/BusActionFactory.ts
+++ b/src/app/digital/actions/addition/BusActionFactory.ts
@@ -3,8 +3,7 @@ import {ConnectionAction} from "core/actions/addition/ConnectionAction";
 
 import {InputPort} from "digital/models/ports/InputPort";
 import {OutputPort} from "digital/models/ports/OutputPort";
-import { Port } from "core/models";
-import { GRID_SIZE } from "core/utils/Constants";
+import {Port} from "core/models";
 
 
 export function CreateBusAction(outputPorts: OutputPort[], inputPorts: InputPort[]): GroupAction {
@@ -32,48 +31,13 @@ export function CreateBusAction(outputPorts: OutputPort[], inputPorts: InputPort
     inputPorts.sort(sortByPos);
     outputPorts.sort(sortByPos);
 
-    var currPort:number = 0;
-    for(currPort = 0; currPort < inputPorts.length; currPort++){
+    // Connect ports by descending y-pos unless they are almost horizontal
+    // in which they are connected left to right
+    for(let currPort = 0; currPort < inputPorts.length; currPort++){
          // Create action
          action.add(new ConnectionAction(designer, outputPorts[currPort]!, inputPorts[currPort]!));
          // wire.setAsStraight(true); @TODO
     }
-
-
-
-
-    // Connect closest pairs of input and output ports
-    // while (outputPorts.length > 0) {
-    //     // Find closest pair of input and output ports
-    //     const max = {dist: -Infinity, in: undefined as InputPort | undefined, out: undefined as OutputPort | undefined};
-    //     outputPorts.forEach((outPort) => {
-
-    //         // Find the closest input port
-    //         const min = {dist: Infinity, in: undefined as InputPort | undefined};
-    //         inputPorts.forEach((inPort) => {
-    //             // Calculate distance between target pos of ports
-    //             const dist = outPort.getWorldTargetPos().distanceTo(inPort.getWorldTargetPos());
-    //             if (dist < min.dist) {
-    //                 min.dist = dist;
-    //                 min.in = inPort;
-    //             }
-    //         });
-
-    //         if (min.dist > max.dist) {
-    //             max.dist = min.dist;
-    //             max.in = min.in;
-    //             max.out = outPort;
-    //         }
-    //     });
-
-    //     // Create action
-    //     action.add(new ConnectionAction(designer, max.out!, max.in!));
-    //     // wire.setAsStraight(true); @TODO
-
-    //     // Remove ports from array
-    //     inputPorts.splice(inputPorts.indexOf(max.in!), 1);
-    //     outputPorts.splice(outputPorts.indexOf(max.out!), 1);
-    // }
 
     return action;
 }

--- a/src/app/digital/actions/addition/BusActionFactory.ts
+++ b/src/app/digital/actions/addition/BusActionFactory.ts
@@ -22,7 +22,7 @@ export function CreateBusAction(outputPorts: OutputPort[], inputPorts: InputPort
     // Sort inputs/outputs by their position
     const sortByPos = (a: Port, b: Port) => {
         const p1 = a.getWorldTargetPos(), p2 = b.getWorldTargetPos();
-        if (Math.abs(p2.y - p1.y) <= .25){ // If same-ish-y, sort by x from LtR
+        if (Math.abs(p1.y - p2.y) <= .25){ // If same-ish-y, sort by x from LtR
             return p1.x - p2.x;
         }
         return p1.y - p2.y; // Sort by y-pos from Top to Bottom


### PR DESCRIPTION
Ports will initially be sorted by y position unless the difference is small in which it will sort by x position (this is to handle horizontal components)
Fixes #882 