### PR TITLE
ContextMenu Improvement

### DIFF
--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -47,31 +47,6 @@ export const ContextMenu = ({ info, paste }: Props) => {
 
     const [{ posX,posY }, setPos] = useState({ posX:0,posY:0 });
 
-    /*Position changes are calculated using the react hook so that the
-     *context menu does not jump around during other update events.
-    */
-    useEffect(() => {
-        let pos = input?.getMousePos();
-        if (!menu.current)
-            throw new Error("ContextMenu failed: menu.current is null");
-
-        const offset = 1;
-        const contextMenuWidth = menu.current.getBoundingClientRect().width;
-        const contextMenuHeight = menu.current.getBoundingClientRect().height;
-
-        /* Relocate context menu to opposite side of cursor if it were to go off-screen */
-        if (pos.x+ contextMenuWidth > window.innerWidth)
-            pos.x -= contextMenuWidth - offset;
-
-        if (pos.y + contextMenuHeight + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET > window.innerHeight)
-            pos.y -= contextMenuHeight - offset;
-
-        //updates position state
-        setPos({ posX:pos.x, posY:pos.y });
-
-        // Update context menu position on canvas
-        menuPos = camera.getWorldPos(input.getMousePos());
-    }, [isOpen]);
     useEffect(() => {
         if (!input)
             return;
@@ -84,6 +59,37 @@ export const ContextMenu = ({ info, paste }: Props) => {
         });
     }, [input])
 
+    if (isOpen) {
+        dispatch(CloseContextMenu());
+    }
+    /*Position changes are calculated using the react hook so that the
+     *context menu does not jump around during other update events.
+    */
+    useEffect(() => {
+        if(isOpen){
+            let pos = input?.getMousePos();
+
+            if (!menu.current)
+                throw new Error("ContextMenu failed: menu.current is null");
+
+            const offset = 1;
+            const contextMenuWidth = menu.current.getBoundingClientRect().width;
+            const contextMenuHeight = menu.current.getBoundingClientRect().height;
+
+
+            if (pos.x+ contextMenuWidth > window.innerWidth)
+                pos.x -= contextMenuWidth - offset;
+
+            if (pos.y + contextMenuHeight + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET > window.innerHeight)
+                pos.y -= contextMenuHeight - offset;
+
+            //updates position state
+            setPos({ posX:pos.x, posY:pos.y });
+
+            // Update context menu position on canvas
+            menuPos = camera.getWorldPos(input.getMousePos());
+        }
+    }, [isOpen]);
 
     const copy = () => {
         const objs = selections.get().filter(o => o instanceof IOObject) as IOObject[];
@@ -146,6 +152,7 @@ export const ContextMenu = ({ info, paste }: Props) => {
     }
 
     const menu = useRef<HTMLDivElement>(null);
+
 
     return (
         <div className="contextmenu"

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -12,6 +12,7 @@ import {CreateDeselectAllAction, CreateGroupSelectAction} from "core/actions/sel
 import {CreateDeleteGroupAction} from "core/actions/deletion/DeleteGroupActionFactory";
 
 import {useSharedDispatch, useSharedSelector} from "shared/utils/hooks/useShared";
+import {useDocEvent} from "shared/utils/hooks/useDocEvent";
 import {CloseContextMenu, OpenContextMenu} from "shared/state/ContextMenu";
 import {useHistory} from "shared/utils/hooks/useHistory";
 
@@ -57,11 +58,8 @@ export const ContextMenu = ({ info, paste }: Props) => {
             else if (ev.type === "mousedown")
                 dispatch(CloseContextMenu());
         });
-    }, [input])
+    }, [input]);
 
-    if (isOpen) {
-        dispatch(CloseContextMenu());
-    }
     /*Position changes are calculated using the react hook so that the
      *context menu does not jump around during other update events.
     */
@@ -90,6 +88,11 @@ export const ContextMenu = ({ info, paste }: Props) => {
             menuPos = camera.getWorldPos(input.getMousePos());
         }
     }, [isOpen]);
+
+    useDocEvent("mousedown", () => {
+        dispatch(CloseContextMenu());
+    });
+
 
     const copy = () => {
         const objs = selections.get().filter(o => o instanceof IOObject) as IOObject[];
@@ -152,7 +155,6 @@ export const ContextMenu = ({ info, paste }: Props) => {
     }
 
     const menu = useRef<HTMLDivElement>(null);
-
 
     return (
         <div className="contextmenu"

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -64,11 +64,8 @@ export const ContextMenu = ({ info, paste }: Props) => {
     useEffect(() => {
         if (!isOpen)
             return;
-
-        let pos = input?.getMousePos();
-
-
         // Updates position state
+        let pos = input?.getMousePos();
         setPos({ posX:pos.x, posY:pos.y });
 
 
@@ -146,6 +143,7 @@ export const ContextMenu = ({ info, paste }: Props) => {
 
     const menu = useRef<HTMLDivElement>(null);
 
+    // Adjusts position of menu to keep it on screen
     let pos = V(posX, posY);
     if(menu.current){
         const offset = 1;

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -90,14 +90,13 @@ export const ContextMenu = ({ info, paste }: Props) => {
     }, [isOpen]);
 
     useDocEvent("mousedown", (ev) => {
-        const pos = input.getMouseDownPos();
         if (!menu.current)
             throw new Error("ContextMenu failed: menu.current is null");
 
         const contextMenuWidth = menu.current.getBoundingClientRect().width;
         const contextMenuHeight = menu.current.getBoundingClientRect().height;
 
-        if(pos.x < posX || pos.x > (posX + contextMenuWidth) || pos.y < posY || pos.y > (posY + contextMenuHeight))
+        if(ev.clientX < posX || ev.clientX > (posX + contextMenuWidth) ||  ev.clientY < posY || ev.clientY > (posY + contextMenuHeight))
             dispatch(CloseContextMenu());
     });
 

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -45,6 +45,13 @@ export const ContextMenu = ({info, paste}: Props) => {
 
     let menuPos: Vector;
 
+    /* LEON EXAMPLE
+    const [{posX,posY}, setPos] = useState({x:0,y:0});
+    useEffect(() => {
+
+    }, [isOpen]);
+     */
+
     useEffect(() => {
         if (!input)
             return;

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -65,10 +65,8 @@ export const ContextMenu = ({ info, paste }: Props) => {
         if (!isOpen)
             return;
         // Updates position state
-        let pos = input?.getMousePos();
+        const pos = input?.getMousePos();
         setPos({ posX:pos.x, posY:pos.y });
-
-
     }, [isOpen]);
 
     useDocEvent("mousedown", (ev) => {
@@ -77,7 +75,7 @@ export const ContextMenu = ({ info, paste }: Props) => {
 
         if (!menu.current.contains(ev.target as Node))
             dispatch(CloseContextMenu());
-    });
+    }, []);
 
 
     const copy = () => {
@@ -144,26 +142,24 @@ export const ContextMenu = ({ info, paste }: Props) => {
     const menu = useRef<HTMLDivElement>(null);
 
     // Adjusts position of menu to keep it on screen
-    let pos = V(posX, posY);
-    if(menu.current){
+    const menuPos = V(posX, posY);
+    if (menu.current) {
         const offset = 1;
-        const contextMenuWidth = menu.current.getBoundingClientRect().width;
-        const contextMenuHeight = menu.current.getBoundingClientRect().height;
+        const { width, height } = menu.current.getBoundingClientRect();
 
+        if (menuPos.x + width > window.innerWidth)
+            menuPos.x -= width - offset;
 
-        if (pos.x + contextMenuWidth > window.innerWidth)
-            pos.x -= contextMenuWidth - offset;
-
-        if (pos.y + contextMenuHeight + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET > window.innerHeight)
-            pos.y -= contextMenuHeight - offset;
+        if (menuPos.y + height + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET > window.innerHeight)
+            menuPos.y -= height - offset;
     }
 
     return (
         <div className="contextmenu"
              ref={menu}
              style={{
-                 left: `${pos.x}px`,
-                 top: `${pos.y + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET}px`,
+                 left: `${menuPos.x}px`,
+                 top: `${menuPos.y + HEADER_HEIGHT - CONTEXT_MENU_VERT_OFFSET}px`,
                  visibility: (isOpen ? "initial" : "hidden")
              }}>
             <button title="Cut"        onClick={() => doFunc(onCut)} disabled={selections.amount() === 0}>Cut</button>
@@ -174,5 +170,5 @@ export const ContextMenu = ({ info, paste }: Props) => {
             <button title="Undo" onClick={() => doFunc(onUndo)} disabled={undoHistory.length === 0}>Undo</button>
             <button title="Redo" onClick={() => doFunc(onRedo)} disabled={redoHistory.length === 0}>Redo</button>
         </div>
-   );
+    );
 }

--- a/src/site/shared/containers/ContextMenu/index.tsx
+++ b/src/site/shared/containers/ContextMenu/index.tsx
@@ -89,8 +89,16 @@ export const ContextMenu = ({ info, paste }: Props) => {
         }
     }, [isOpen]);
 
-    useDocEvent("mousedown", () => {
-        dispatch(CloseContextMenu());
+    useDocEvent("mousedown", (ev) => {
+        const pos = input.getMouseDownPos();
+        if (!menu.current)
+            throw new Error("ContextMenu failed: menu.current is null");
+
+        const contextMenuWidth = menu.current.getBoundingClientRect().width;
+        const contextMenuHeight = menu.current.getBoundingClientRect().height;
+
+        if(pos.x < posX || pos.x > (posX + contextMenuWidth) || pos.y < posY || pos.y > (posY + contextMenuHeight))
+            dispatch(CloseContextMenu());
     });
 
 


### PR DESCRIPTION
fixes #914 

Addressing the issue that the context menu jumps around when certain updates occur, such as clicking on the settings button.
The menu now closes instead, when an update occurs.
Before:
![notworking](https://user-images.githubusercontent.com/20589728/156849621-cbf42afe-34d9-429a-9a42-80ad823186ef.gif)
After:
![working](https://user-images.githubusercontent.com/20589728/156849628-c405f932-a813-407a-8fc4-655cc637db45.gif)

