### PR TITLE
HeaderRight dropdown text and picture properly centered

### DIFF
--- a/src/site/shared/containers/Header/Right/index.scss
+++ b/src/site/shared/containers/Header/Right/index.scss
@@ -138,13 +138,13 @@
                 margin: 0;
             }
             & span {
-                padding: 12px 16px;
+                padding: 16px 16px;
 
                 color: $secondary-color;
             }
             & img {
                 display: inline;
-
+                margin-top: 3px;
                 vertical-align: middle;
             }
             & div {

--- a/src/site/shared/containers/Header/Right/index.scss
+++ b/src/site/shared/containers/Header/Right/index.scss
@@ -138,9 +138,9 @@
                 margin: 0;
             }
             & span {
-                padding: 16px 16px;
-
+                padding: 12px 16px;
                 color: $secondary-color;
+                vertical-align: middle;
             }
             & img {
                 display: inline;


### PR DESCRIPTION
To center the text and picture in the dropdown menu, I added a margin to the img to center it in the button, and vertically aligned the text to the middle.

Fixes: #1009 


Old button view

<img src="https://user-images.githubusercontent.com/72285616/158254884-71525c0f-ee0e-4548-8a78-c55fa6bba150.png" width=50% height=50%>

New Button view


<img src="https://user-images.githubusercontent.com/72285616/158256248-2ca8ffe2-9549-4177-95a9-804ae3ec7c71.png" width=50% height=50%>

