### PR TITLE
Wire split fix

### DIFF
--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -148,19 +148,20 @@ export class ViewManager<
         const v = this.getView(m.id);
         v.onPropChange(key);
 
-        if (key === "zIndex")
+        if (key === "zIndex"){
             this.depthMap[v.getLayer() + LAYER_OFFSET].editEntry(m.id, m.zIndex, val as number);
-
-        // Also, if the object is a component, update it's ports too
-        if (m.baseKind === "Component") {
-            this.circuit.getPortsFor(m).forEach((p) => this.onEditObj(p as Obj, key, val));
             return;
-        }
+         }
+        // Also, if the object is a component, update it's ports too
+         if (m.baseKind === "Component") {
+             this.circuit.getPortsFor(m).forEach((p) => this.onEditObj(p as Obj, key, val));
+             return;
+         }
 
-        // And if the object is a port, then update it's wires
-        if (m.baseKind === "Port") {
-            this.circuit.getWiresFor(m).forEach((w) => this.onEditObj(w as Obj, key, val));
-        }
+         // And if the object is a port, then update it's wires
+         if (m.baseKind === "Port") {
+             this.circuit.getWiresFor(m).forEach((w) => this.onEditObj(w as Obj, key, val));
+         }
     }
 
     public onRemoveObj(m: Obj) {

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -153,6 +153,11 @@ export class ViewManager<
             return;
          }
         // Also, if the object is a component, update it's ports too
+        // The problem with this is that the action/event for an edited object
+        // already goes through and gets all the ports and updates their zIndex
+        // so in those cases the below is redundant and creates errors. But the
+        //action's behavior is probably how it should be handled, so the return
+        //above was added as a bandaid fix
          if (m.baseKind === "Component") {
              this.circuit.getPortsFor(m).forEach((p) => this.onEditObj(p as Obj, key, val));
              return;


### PR DESCRIPTION
Bandaid fix for crash when splitting a wire after moving a component. Stops `onEditObj` from attempting to iterate through and update ports and wires for a component since whatever action calls onEditObj already handles that. Honestly probably wasn't worth branching but I was expecting a much more complicated fix.

Duplicate commit messages, the second one just adds a comment explaining the issue alongside the fix