### PR TITLE
Wire split fix + node selection

### DIFF
--- a/src/app/core/tools/WiringTool.ts
+++ b/src/app/core/tools/WiringTool.ts
@@ -5,11 +5,13 @@ import {InputManagerEvent} from "core/utils/InputManager";
 
 import {Place} from "core/actions/units/Place";
 
-import {AnyPort} from "core/models/types";
+import {AnyPort, AnyNode} from "core/models/types";
 
 import {CreateWire} from "core/models/utils/CreateWire";
 
 import {PortView} from "core/views/PortView";
+
+import {NodeView} from "core/views/NodeView";
 
 
 export const WiringTool = (() => {
@@ -41,6 +43,17 @@ export const WiringTool = (() => {
             .filter((view) => view.isWireable() && (port ? view.isWireableWith(port) : true));
 
         if (validPorts.length === 0)
+            return undefined;
+
+        // The below is necessary because getNearestObj in viewManager always finds a port before their parent node
+        // so trying to select a node immediately starts wiring one of its ports. So here were check to see if there
+        // is also a node under the mouse and if there is we tell the tool there are no valid ports to start wiring
+        const allNodes = [...viewManager]
+            .filter((view) => (view.getObj().kind === "DigitalNode")) as Array<NodeView<AnyNode>>;
+        const validNodes = allNodes
+            .filter((view) => view.contains(worldMousePos));
+
+        if(validNodes.length !== 0)
             return undefined;
 
         // Find closest port to the mouse

--- a/src/app/core/tools/WiringTool.ts
+++ b/src/app/core/tools/WiringTool.ts
@@ -45,16 +45,6 @@ export const WiringTool = (() => {
         if (validPorts.length === 0)
             return undefined;
 
-        // The below is necessary because getNearestObj in viewManager always finds a port before their parent node
-        // so trying to select a node immediately starts wiring one of its ports. So here were check to see if there
-        // is also a node under the mouse and if there is we tell the tool there are no valid ports to start wiring
-        const allNodes = [...viewManager]
-            .filter((view) => (view.getObj().kind === "DigitalNode")) as Array<NodeView<AnyNode>>;
-        const validNodes = allNodes
-            .filter((view) => view.contains(worldMousePos));
-
-        if(validNodes.length !== 0)
-            return undefined;
 
         // Find closest port to the mouse
         return validPorts
@@ -77,6 +67,9 @@ export const WiringTool = (() => {
                         input.getTouchCount() === 1) ||
                     (event.type === "click")
                 ) && (port !== undefined)
+                // without this the wiring tool still takes priority over DefaultTool when
+                // trying to select a node
+                && (info.circuit.getPortParent(port).kind !== "DigitalNode")
             );
         },
         shouldDeactivate(event: InputManagerEvent, {}: CircuitInfo): boolean {

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -226,7 +226,7 @@ export class ViewManager<
     }
 
     // TODO
-    // The node issue should eventually solve itself
+    // The node issue should eventually solve itself with the planned view refactor
     public findNearestObj(
         pos: Vector,
         filter = (_: Obj) => true,

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -236,7 +236,6 @@ export class ViewManager<
             if (view.contains(pos))
                 return view.getObj();
         }
-
     }
 
     public findObjects(bounds: Transform): Obj[] {

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -230,20 +230,18 @@ export class ViewManager<
         filter = (_: Obj) => true,
     ): undefined | Obj {
         // Loop through each view
-//         for (const view of this) {
-//             if (!filter(view.getObj()))
-//                 continue;
-//             if (view.contains(pos))
-//                 return view.getObj();
-//         }
-
-        const box = Transform.FromCorners(pos, pos);
-        const objects = this.findObjects(box);
-        const nonPortObjs = objects.filter((o) => (o.baseKind !== "Port"));
-        if(nonPortObjs.length !== 0)
-            return nonPortObjs[0];
-        if (objects.length !== 0)
-            return objects[0];
+        for (const view of this) {
+            if (!filter(view.getObj()))
+                continue;
+            if (view.contains(pos)){
+                if(view.getObj().baseKind === "Port"){
+                        if (this.getView(this.circuit.getPortParent(view.getObj()).id).contains(pos)){
+                            return this.circuit.getPortParent(view.getObj());
+                        }
+                    }
+                return view.getObj();
+            }
+        }
 
     }
 

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -233,14 +233,8 @@ export class ViewManager<
         for (const view of this) {
             if (!filter(view.getObj()))
                 continue;
-            if (view.contains(pos)){
-                if(view.getObj().baseKind === "Port"){
-                        if (this.getView(this.circuit.getPortParent(view.getObj()).id).contains(pos)){
-                            return this.circuit.getPortParent(view.getObj());
-                        }
-                    }
+            if (view.contains(pos))
                 return view.getObj();
-            }
         }
 
     }

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -226,12 +226,7 @@ export class ViewManager<
     }
 
     // TODO
-    // Add an exception for Nodes
-    // Currently if there are multiple Obj directly on top of each other
-    // this will select one of them arbitrarily. In most cases this isn't
-    // a big deal but nodes and their input and output ports all occupy the
-    // same x, y position so this will typically give you a port rather
-    // than the node
+    // The node issue should eventually solve itself
     public findNearestObj(
         pos: Vector,
         filter = (_: Obj) => true,
@@ -240,8 +235,20 @@ export class ViewManager<
         for (const view of this) {
             if (!filter(view.getObj()))
                 continue;
-            if (view.contains(pos))
+            if (view.contains(pos)){
+                const obj = view.getObj();
+                if (obj.baseKind === "Port"){
+                    // Since nodes and their ports are directly on top of each other,
+                    // we check to see if the port's parent also contains pos and return
+                    // that instead
+                    const parent = this.circuit.getPortParent(obj);
+                    const parentView = this.getView(parent.id);
+                    if(parentView.contains(pos)){
+                        return parent as Obj;
+                    }
+                }
                 return view.getObj();
+            }
         }
     }
 

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -225,6 +225,13 @@ export class ViewManager<
         }
     }
 
+    // TODO
+    // Add an exception for Nodes
+    // Currently if there are multiple Obj directly on top of each other
+    // this will select one of them arbitrarily. In most cases this isn't
+    // a big deal but nodes and their input and output ports all occupy the
+    // same x, y position so this will typically give you a port rather
+    // than the node
     public findNearestObj(
         pos: Vector,
         filter = (_: Obj) => true,

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -148,19 +148,20 @@ export class ViewManager<
         const v = this.getView(m.id);
         v.onPropChange(key);
 
-        if (key === "zIndex")
+        if (key === "zIndex"){
             this.depthMap[v.getLayer() + LAYER_OFFSET].editEntry(m.id, m.zIndex, val as number);
-
-        // Also, if the object is a component, update it's ports too
-        if (m.baseKind === "Component") {
-            this.circuit.getPortsFor(m).forEach((p) => this.onEditObj(p as Obj, key, val));
             return;
-        }
+         }
+        // Also, if the object is a component, update it's ports too
+         if (m.baseKind === "Component") {
+             this.circuit.getPortsFor(m).forEach((p) => this.onEditObj(p as Obj, key, val));
+             return;
+         }
 
-        // And if the object is a port, then update it's wires
-        if (m.baseKind === "Port") {
-            this.circuit.getWiresFor(m).forEach((w) => this.onEditObj(w as Obj, key, val));
-        }
+         // And if the object is a port, then update it's wires
+         if (m.baseKind === "Port") {
+             this.circuit.getWiresFor(m).forEach((w) => this.onEditObj(w as Obj, key, val));
+         }
     }
 
     public onRemoveObj(m: Obj) {

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -230,12 +230,21 @@ export class ViewManager<
         filter = (_: Obj) => true,
     ): undefined | Obj {
         // Loop through each view
-        for (const view of this) {
-            if (!filter(view.getObj()))
-                continue;
-            if (view.contains(pos))
-                return view.getObj();
-        }
+//         for (const view of this) {
+//             if (!filter(view.getObj()))
+//                 continue;
+//             if (view.contains(pos))
+//                 return view.getObj();
+//         }
+
+        const box = Transform.FromCorners(pos, pos);
+        const objects = this.findObjects(box);
+        const nonPortObjs = objects.filter((o) => (o.baseKind !== "Port"));
+        if(nonPortObjs.length !== 0)
+            return nonPortObjs[0];
+        if (objects.length !== 0)
+            return objects[0];
+
     }
 
     public findObjects(bounds: Transform): Obj[] {

--- a/src/app/core/views/ViewManager.ts
+++ b/src/app/core/views/ViewManager.ts
@@ -153,6 +153,11 @@ export class ViewManager<
             return;
          }
         // Also, if the object is a component, update it's ports too
+        // The problem with this is that the action/event for an edited object
+        // already goes through and gets all the ports and updates their zIndex
+        // so in those cases the below is redundant and creates errors. But the
+        //action's behavior is probably how it should be handled, so the return
+        //above was added as a bandaid fix
          if (m.baseKind === "Component") {
              this.circuit.getPortsFor(m).forEach((p) => this.onEditObj(p as Obj, key, val));
              return;

--- a/src/app/core/views/portinfo/digital/index.ts
+++ b/src/app/core/views/portinfo/digital/index.ts
@@ -42,7 +42,7 @@ export const DigitalPortInfo: PortInfoRecord<DigitalComponent> = {
         // Generate configs for 2->8 input ports
         PositionConfigs: [2,3,4,5,6,7,8].map((numInputs) => ({
             "inputs":  CalcPortPositions(numInputs, 0.5 - DEFAULT_BORDER_WIDTH/2, 1, V(-1, 0)),
-            "outputs": [CalcPortPos(V(0.5, 0), V(1, 0))], // 1 output
+            "outputs": [CalcPortPos(V(0.47, 0), V(1, 0))], // 1 output
         })),
     },
 };


### PR DESCRIPTION
Bandaid fix for the crash when splitting a wire after moving one of the components. Also corrects nodes immediately starting to wire instead of selecting on click