### PR TITLE
More flesh on CircuitInternal skeleton

### DIFF
--- a/src/app/core/internal/impl/CircuitInternal.ts
+++ b/src/app/core/internal/impl/CircuitInternal.ts
@@ -1,72 +1,172 @@
-import {GUID} from "core/schema/GUID";
+import { GUID } from "core/schema/GUID";
 
-import {Schema}       from "../../schema";
-import {GetDebugInfo} from "../utils/Debug";
+import { Schema } from "../../schema";
+import { GetDebugInfo } from "../utils/Debug";
+import { CircuitOp, InvertMultiOp, MultiOp } from "./CircuitOps";
+import { ComponentInfoProvider, PortConfig } from "./ComponentInfo";
 
-import {DebugOptions}      from "./DebugOptions";
-import {HistoryManager}    from "./HistoryManager";
-import {SelectionsManager} from "./SelectionsManager";
-
+import { HistoryManager } from "./HistoryManager";
 
 export class CircuitInternal {
-    protected readonly circuit: Schema.Circuit;
-
-    protected readonly selections: SelectionsManager;
     protected readonly history: HistoryManager;
-
-    public debugOptions: DebugOptions;
-    public isLocked: boolean;
+    protected readonly componentTypes: ComponentInfoProvider;
 
     protected objMap: Map<GUID, Schema.Obj>;
     protected componentPortsMap: Map<GUID, Schema.Port[]>; // components to ports
     protected connectionsMap: Map<GUID, Schema.Wire[]>; // Ports to wires
 
-    public constructor() {
-        this.circuit = Schema.DefaultCircuit();
-        this.selections = new SelectionsManager();
+    // Explicit variable only needed for asserts.  JS threading model means no mutex needed, but it
+    // is possible for an async call mid-transaction to yield control-flow to another task and break
+    // atomicity of transactions.  Any behavior that yields control-flow mid transaction is ILLEGAL,
+    // and thus guarded by asserts.
+    protected transaction: boolean;
+
+    // TODO: Can the emitted events be completely generated from this Ops list?
+    protected transactionOps: CircuitOp[];
+
+    public constructor(componentsTypes: ComponentInfoProvider) {
         this.history = new HistoryManager();
+        this.componentTypes = componentsTypes;
 
         this.objMap = new Map();
         this.componentPortsMap = new Map();
+        this.connectionsMap = new Map();
 
-        this.debugOptions = {
-            debugCullboxes:       false,
-            debugNoFill:          false,
-            debugPressableBounds: false,
-            debugSelectionBounds: false,
-        };
-        this.isLocked = false;
+        this.transaction = false;
+        this.transactionOps = [];
     }
 
-    public addObj(obj: Schema.Obj) {
-        if (this.objMap.has(obj.id))
-            throw new Error(`CircuitInternal: Attempted to add obj ${GetDebugInfo(obj)} which already existed in the circuit!`);
-
-        this.circuit.objects.push(obj);
-        this.objMap.set(obj.id, obj);
+    private assertOwnObject(obj: Schema.Obj): void {
+        if (this.objMap.get(obj.id) !== obj)
+            throw new Error("Circuit does not own provided object");
     }
-    public removeObj(obj: Schema.Obj) {
-        if (!this.objMap.has(obj.id))
-            throw new Error(`CircuitInternal: Attempted to remove obj ${GetDebugInfo(obj)} which does not exist in the circuit!`);
-
-        // TODO: make this more efficient, somehow keep track of the indices of each object
-        this.circuit.objects.splice(this.circuit.objects.indexOf(obj), 1);
-        this.objMap.delete(obj.id);
+    private assertHasGUID(id: GUID): void {
+        if (!this.objMap.has(id))
+            throw new Error("Circuit does not own provided GUID");
+    }
+    // Public for use by i.e. the Renderer, Propagators.
+    public assertTransactionState(st: boolean): void {
+        if (this.transaction != st)
+            throw new Error("Unexpectedly in transaction state");
     }
 
-    public setPropFor<O extends Schema.Obj, K extends keyof O["props"]>(obj: O, key: K, val: O["props"][K]) {
+    public beginTransaction(): void {
+        this.assertTransactionState(false);
+        this.transaction = true;
+    }
+    public commitTransaction(): MultiOp | undefined {
+        this.assertTransactionState(true);
+        let op: MultiOp | undefined = undefined;
+        if (this.transactionOps.length > 0) {
+            op = { kind: "MultiOp", ops: this.transactionOps };
+            this.history.push(op);
+            this.transactionOps = [];
+
+            // TODO: Emit events for changes...
+        }
+        this.transaction = false;
+        return op;
+    }
+    public cancelTransaction(): void {
+        this.assertTransactionState(true);
+        if (this.transactionOps.length > 0) {
+            InvertMultiOp({ kind: "MultiOp", ops: this.transactionOps }).ops.forEach(rollbackOp => {
+                this.applyOp(rollbackOp);
+            });
+            // TODO: Dump in-progress events
+            this.transactionOps = [];
+        }
+        this.transaction = false;
+    }
+
+    private undoRedoHelper(op?: MultiOp): boolean {
+        if (op === undefined)
+            return false;
+
+        this.beginTransaction();
+        op.ops.forEach(o => this.applyOp(o));
+        this.commitTransaction();
+
+        return true;
+    }
+    public undo(): boolean {
+        return this.undoRedoHelper(this.history.undo());
+    }
+    public redo(): boolean {
+        return this.undoRedoHelper(this.history.redo());
+    }
+
+    // Wrap all mutations in this proto-operational-transform function as guard-rails of our impl.
+    protected applyOp(op: CircuitOp): void {
+        this.transactionOps.push(op);
+        // TODO: Accumulate changes here / prepare events
+        switch (op.kind) { /* TODO: all of the mutate logic */ }
+    }
+
+    //
+    // Convenience functions around CircuitOps
+    //
+
+    public placeComponent(kind: string, props: Schema.Component["props"]): void {
+        const g: GUID = ""; // TODO: generatre
+        this.applyOp({
+            kind: "PlaceComponentOp",
+            inverted: false,
+            c: {
+                baseKind: "Component",
+                kind: kind,
+                id: g,
+                props: props,
+            },
+            wires: [],
+            ports: [], // NOTE: Ports are added separately in "setPortConfig".
+        });
+    }
+
+    // TODO: Should this take a component object for type safety?
+    public replaceComponent(id: GUID, newKind: string): void {
+        // TODO: Check that component's current port list is compatable with the "newKind" ComponentInfo
+        // TODO: Maybe this needs a dedicated Op b/c updating kind isn't covered by `SetPropertyOp`
         throw new Error("Unimplemented");
     }
-    public getPropFrom<O extends Schema.Obj, K extends keyof O["props"]>(obj: O, key: K): O["props"][K] | undefined {
+
+    public deleteObject(id: GUID): void {
+        // TODO: one of these per type?
         throw new Error("Unimplemented");
     }
 
-    public getObjs(): readonly Schema.Obj[] {
-        return this.circuit.objects;
+    public setPropFor<O extends Schema.Obj, K extends keyof O["props"]>(obj: O, key: K, val?: O["props"][K]) {
+        this.assertOwnObject(obj);
+        const oldVal: O["props"][K] | undefined = obj[key];
+        this.applyOp({ kind: "SetPropertyOp", key: String(key), newVal: val, oldVal: oldVal });
     }
 
-    public getObjByID(id: GUID): Schema.Obj | undefined {
-        return this.getObjByID(id);
+    public setPortConfig(id: GUID, p: PortConfig): void {
+        const obj = this.getCompByID(id);
+        if (!obj)
+            throw new Error("Failed to set port config: invalid GUID");
+        const componentInfo = this.componentTypes.get(obj.kind);
+        if (componentInfo === undefined)
+            throw new Error("Failed to set port config: Unknown component type (this is really bad)");
+        const ports = componentInfo.makePortsForConfig(id, p);
+        if (ports === undefined)
+            throw new Error("Failed to set port config: Invalid port config");
+
+        // NOTE: "applyOp" will need to double-check this list of ports is valid.
+        this.applyOp({ kind: "SetComponentPortsOp", component: id, newPorts: ports })
+    }
+
+    //
+    // Getters below.  Returns references must only be used ephemerally!
+    //  (i.e. never across async/mutate boundaries)
+    //
+
+    public getPropFrom<O extends Schema.Obj, K extends keyof O["props"]>(id: GUID): O["props"][K] | undefined {
+        throw new Error("Unimplemented");
+    }
+
+    public getObjs(): IterableIterator<Schema.Obj> {
+        return this.objMap.values();
     }
 
     private getBaseKindByID<O extends Schema.Obj>(id: GUID, kind: O["baseKind"]): O | undefined {

--- a/src/app/core/internal/impl/CircuitInternal.ts
+++ b/src/app/core/internal/impl/CircuitInternal.ts
@@ -34,9 +34,9 @@ export class CircuitInternal {
     // TODO: Can the emitted events be completely generated from this Ops list?
     protected transactionOps: CircuitOp[];
 
-    public constructor(componentsTypes: ComponentInfoProvider) {
+    public constructor(componentTypes: ComponentInfoProvider) {
         this.history = new HistoryManager();
-        this.componentTypes = componentsTypes;
+        this.componentTypes = componentTypes;
 
         this.objMap = new Map();
         this.componentPortsMap = new Map();
@@ -81,7 +81,7 @@ export class CircuitInternal {
         this.assertTransactionState(true);
         if (this.transactionOps.length > 0) {
             InvertMultiOp({ kind: "MultiOp", ops: this.transactionOps }).ops
-                .forEach((rollbackOp) => { this.applyOp(rollbackOp); });
+                .forEach((rollbackOp) => this.applyOp(rollbackOp));
             // TODO: Dump in-progress events
             this.transactionOps = [];
         }
@@ -153,10 +153,10 @@ export class CircuitInternal {
         if (!obj)
             throw new Error("Failed to set port config: invalid GUID");
         const componentInfo = this.componentTypes.get(obj.kind);
-        if (componentInfo === undefined)
+        if (!componentInfo)
             throw new Error("Failed to set port config: Unknown component type (this is really bad)");
         const ports = componentInfo.makePortsForConfig(id, portConfig);
-        if (ports === undefined)
+        if (!ports)
             throw new Error("Failed to set port config: Invalid port config");
 
         // NOTE: "applyOp" will need to double-check this list of ports is valid.

--- a/src/app/core/internal/impl/CircuitOps.ts
+++ b/src/app/core/internal/impl/CircuitOps.ts
@@ -1,4 +1,4 @@
-import { Schema } from "core/schema"
+import {Schema} from "core/schema"
 
 // Sequence of ops that should be applied atomically.  This is not a proper op itself currently,
 // but maybe it should be?
@@ -38,7 +38,7 @@ export interface SetPropertyOp {
 
 export interface SetComponentPortsOp {
     kind: "SetComponentPortsOp";
-    component: Schema.GUID,
+    component: Schema.GUID;
     newPorts?: Schema.Port[];
     oldPorts?: Schema.Port[];
 }
@@ -58,6 +58,9 @@ export function InvertCircuitOp(op: CircuitOp): CircuitOp {
     }
 }
 
-export function InvertMultiOp(op: MultiOp): MultiOp {
-    return { kind: op.kind, ops: [...op.ops].reverse().map((a) => InvertCircuitOp(a)) };
+export function InvertMultiOp({ kind, ops }: MultiOp): MultiOp {
+    return {
+        kind,
+        ops: ops.map(InvertCircuitOp).reverse(),
+    }
 }

--- a/src/app/core/internal/impl/CircuitOps.ts
+++ b/src/app/core/internal/impl/CircuitOps.ts
@@ -1,0 +1,63 @@
+import { Schema } from "core/schema"
+
+// Sequence of ops that should be applied atomically.  This is not a proper op itself currently,
+// but maybe it should be?
+export interface MultiOp {
+    kind: "MultiOp";
+    ops: CircuitOp[];
+}
+
+export interface PlaceComponentOp {
+    kind: "PlaceComponentOp";
+    inverted: boolean;
+    c: Schema.Component;
+    ports: Schema.Port[];
+    wires: Schema.Wire[];
+}
+
+export interface ConnectWireOp {
+    kind: "ConnectWireOp";
+    inverted: boolean;
+    w: Schema.Wire;
+}
+
+export interface SplitWireOp {
+    kind: "SplitWireOp";
+    inverted: boolean;
+    tgt: Schema.Wire;
+    new: Schema.Wire;
+    node: Schema.Component;
+}
+
+export interface SetPropertyOp {
+    kind: "SetPropertyOp";
+    key: string;
+    newVal?: Schema.Prop;
+    oldVal?: Schema.Prop;
+}
+
+export interface SetComponentPortsOp {
+    kind: "SetComponentPortsOp";
+    component: Schema.GUID,
+    newPorts?: Schema.Port[];
+    oldPorts?: Schema.Port[];
+}
+
+export type CircuitOp = PlaceComponentOp | ConnectWireOp | SplitWireOp | SetPropertyOp | SetComponentPortsOp;
+
+export function InvertCircuitOp(op: CircuitOp): CircuitOp {
+    switch (op.kind) {
+        case "PlaceComponentOp":
+        case "ConnectWireOp":
+        case "SplitWireOp":
+            return { ...op, inverted: !op.inverted };
+        case "SetPropertyOp":
+            return { ...op, newVal: op.oldVal, oldVal: op.newVal };
+        case "SetComponentPortsOp":
+            return { ...op, newPorts: op.oldPorts, oldPorts: op.newPorts };
+    }
+}
+
+export function InvertMultiOp(op: MultiOp): MultiOp {
+    return { kind: op.kind, ops: [...op.ops].reverse().map((a) => InvertCircuitOp(a)) };
+}

--- a/src/app/core/internal/impl/ComponentInfo.ts
+++ b/src/app/core/internal/impl/ComponentInfo.ts
@@ -28,13 +28,15 @@ export interface ComponentInfoProvider {
 
 // TODO: seems kind of heavy
 export function IsValidPortList(info: ComponentInfo, ports: Schema.Port[]): boolean {
+    // Count ports in each group
     const countMap = new Map<string, number>();
     ports.forEach(({ group }) =>
         countMap.set(group, (countMap.get(group) ?? 0) + 1));
 
-    const counts: Record<string, number> = {};
-    info.portGroups.forEach((g) =>
-        { counts[g] = countMap.get(g) ?? -1});
+    // Convert map to record
+    const counts = {} as Record<string, number>;
+    countMap.forEach((v, k) => counts[k] = v);
+
     return info.isValidPortConfig({ counts });
 }
 

--- a/src/app/core/internal/impl/ComponentInfo.ts
+++ b/src/app/core/internal/impl/ComponentInfo.ts
@@ -1,0 +1,112 @@
+import { Schema } from "core/schema";
+
+export interface PortConfig {
+    counts: number[];
+};
+
+// Describes legal component configurations.
+// NOTE: The configuration wherein each port group has zero ports is IMPLICITLY LEGAL.
+export interface ComponentInfo {
+    readonly kind: string;
+    readonly portGroups: string[];
+    readonly defaultPortConfig: PortConfig;
+
+    isValidPortConfig(p: PortConfig): boolean;
+    makePortsForConfig(id: Schema.GUID, p: PortConfig): Schema.Port[] | undefined;
+
+    // i.e. Prevents fan-in on digital ports, could prevent illegal self-connectivity
+    isValidPortConnectivity(wires: Map<Schema.Port, Schema.Port[]>): boolean;
+
+    // Also i.e. thumbnail, display name, description, etc.
+}
+
+export interface ComponentInfoProvider {
+    get(kind: string): ComponentInfo | undefined;
+}
+
+// TODO: seems kind of heavy
+export function IsValidPortList(info: ComponentInfo, ports: Schema.Port[]): boolean {
+    let countMap = new Map(info.portGroups.map(g => [g, Number(0)]));
+    for (const p of ports) {
+        let count = countMap.get(p.group);
+        if (count === undefined)
+            return false;
+        count++;
+    }
+    let counts: number[] = info.portGroups.map(g => countMap.get(g) ?? -1);
+    return info.isValidPortConfig({ counts: counts });
+}
+
+//
+// Example "Digital" implementation
+//
+
+class BasicGateInfo implements ComponentInfo {
+    private readonly _kind: string;
+
+    // i.e. with thumbnail, display name, description, etc.
+    public constructor(kind: string) {
+        this._kind = kind;
+    }
+
+    public get kind(): string {
+        return this._kind;
+    }
+    public readonly portGroups: string[] = ["IN", "OUT"];
+    public readonly defaultPortConfig: PortConfig = ({ counts: [2, 1] });
+
+    public isValidPortConfig(p: PortConfig): boolean {
+        // At least 2 inputs, exactly 1 output
+        return p.counts[0] >= 2 && p.counts[1] == 1;
+    }
+
+    public makePortsForConfig(componentID: Schema.GUID, p: PortConfig): Schema.Port[] {
+        let ports: Schema.Port[] = [];
+        p.counts.forEach((count, groupIdx) => {
+            for (let groupPos = 0; groupPos < count; ++groupPos) {
+                ports.push({
+                    baseKind: "Port",
+                    kind: "DigitalPort",
+                    id: "", // TODO: generate
+
+                    parent: componentID,
+                    group: this.portGroups[groupIdx],
+                    index: groupPos,
+                    props: {},
+                });
+            }
+        });
+        return ports;
+    }
+
+    public isValidPortConnectivity(wires: Map<Schema.Port, Schema.Port[]>): boolean {
+        for (const [me, o] of wires.entries()) {
+            // Prevent fan-in on input ports
+            if (me.group == "IN" && o.length > 1)
+                return false;
+        }
+        return true;
+    }
+};
+const ANDGateInfo: ComponentInfo = new BasicGateInfo("ANDGate");
+const ORGateInfo: ComponentInfo = new BasicGateInfo("ORGate");
+// etc...
+
+class ExampleDigitalComponentInfoProvider implements ComponentInfoProvider {
+    private map: Map<Schema.GUID, ComponentInfo>;
+    public constructor() {
+        this.map = new Map([
+            ["ANDGate", ANDGateInfo],
+            ["ORGate", ORGateInfo],
+            // etc...
+        ]);
+    }
+
+    get(kind: Schema.GUID): ComponentInfo | undefined {
+        return this.map.get(kind)
+    }
+}
+
+export function NewExampleComponentInfoProvider(): ComponentInfoProvider {
+    return new ExampleDigitalComponentInfoProvider();
+}

--- a/src/app/core/internal/impl/ComponentInfo.ts
+++ b/src/app/core/internal/impl/ComponentInfo.ts
@@ -1,11 +1,13 @@
-import { Schema } from "core/schema";
+import {Schema} from "core/schema";
+
 
 export interface PortConfig {
-    counts: number[];
-};
+    counts: Record<string, number>;
+}
 
 // Describes legal component configurations.
-// NOTE: The configuration wherein each port group has zero ports is IMPLICITLY LEGAL.
+// NOTE: The configuration wherein each port group has zero ports is IMPLICITLY LEGAL, because the
+//  component is UNREACHABLE in any propagator.
 export interface ComponentInfo {
     readonly kind: string;
     readonly portGroups: string[];
@@ -26,15 +28,14 @@ export interface ComponentInfoProvider {
 
 // TODO: seems kind of heavy
 export function IsValidPortList(info: ComponentInfo, ports: Schema.Port[]): boolean {
-    let countMap = new Map(info.portGroups.map(g => [g, Number(0)]));
-    for (const p of ports) {
-        let count = countMap.get(p.group);
-        if (count === undefined)
-            return false;
-        count++;
-    }
-    let counts: number[] = info.portGroups.map(g => countMap.get(g) ?? -1);
-    return info.isValidPortConfig({ counts: counts });
+    const countMap = new Map<string, number>();
+    ports.forEach(({ group }) =>
+        countMap.set(group, (countMap.get(group) ?? 0) + 1));
+
+    const counts: Record<string, number> = {};
+    info.portGroups.forEach((g) =>
+        { counts[g] = countMap.get(g) ?? -1});
+    return info.isValidPortConfig({ counts });
 }
 
 //
@@ -42,58 +43,62 @@ export function IsValidPortList(info: ComponentInfo, ports: Schema.Port[]): bool
 //
 
 class BasicGateInfo implements ComponentInfo {
-    private readonly _kind: string;
+    private readonly kindInternal: string;
 
     // i.e. with thumbnail, display name, description, etc.
     public constructor(kind: string) {
-        this._kind = kind;
+        this.kindInternal = kind;
     }
 
     public get kind(): string {
-        return this._kind;
+        return this.kindInternal;
     }
-    public readonly portGroups: string[] = ["IN", "OUT"];
-    public readonly defaultPortConfig: PortConfig = ({ counts: [2, 1] });
+    public get portGroups(): string[] {
+        return Object.keys(this.defaultPortConfig.counts);
+    }
+    public get defaultPortConfig(): PortConfig {
+        return { counts: { "IN": 2, "OUT": 1 } };
+    }
 
     public isValidPortConfig(p: PortConfig): boolean {
         // At least 2 inputs, exactly 1 output
-        return p.counts[0] >= 2 && p.counts[1] == 1;
+        return p.counts["IN"] >= 2 && p.counts["OUT"] === 1;
     }
 
     public makePortsForConfig(componentID: Schema.GUID, p: PortConfig): Schema.Port[] {
-        let ports: Schema.Port[] = [];
-        p.counts.forEach((count, groupIdx) => {
-            for (let groupPos = 0; groupPos < count; ++groupPos) {
+        const ports: Schema.Port[] = [];
+        for (const group of Object.keys(p.counts)) {
+            for (let index = 0; index  < p.counts[group ]; ++index) {
                 ports.push({
                     baseKind: "Port",
-                    kind: "DigitalPort",
-                    id: "", // TODO: generate
+                    kind:     "DigitalPort",
+                    id:       "", // TODO: generate
 
                     parent: componentID,
-                    group: this.portGroups[groupIdx],
-                    index: groupPos,
-                    props: {},
+                    group,
+                    index,
+                    props:  {}, // TODO: any manditory props for Digial ports
                 });
             }
-        });
+        }
         return ports;
     }
 
     public isValidPortConnectivity(wires: Map<Schema.Port, Schema.Port[]>): boolean {
         for (const [me, o] of wires.entries()) {
             // Prevent fan-in on input ports
-            if (me.group == "IN" && o.length > 1)
+            if (me.group === "IN" && o.length > 1)
                 return false;
         }
         return true;
     }
-};
+}
 const ANDGateInfo: ComponentInfo = new BasicGateInfo("ANDGate");
 const ORGateInfo: ComponentInfo = new BasicGateInfo("ORGate");
 // etc...
 
 class ExampleDigitalComponentInfoProvider implements ComponentInfoProvider {
-    private map: Map<Schema.GUID, ComponentInfo>;
+    private readonly map: Map<string, ComponentInfo>;
     public constructor() {
         this.map = new Map([
             ["ANDGate", ANDGateInfo],
@@ -102,7 +107,7 @@ class ExampleDigitalComponentInfoProvider implements ComponentInfoProvider {
         ]);
     }
 
-    get(kind: Schema.GUID): ComponentInfo | undefined {
+    public get(kind: string): ComponentInfo | undefined {
         return this.map.get(kind)
     }
 }

--- a/src/app/core/internal/impl/ComponentInfo.ts
+++ b/src/app/core/internal/impl/ComponentInfo.ts
@@ -28,15 +28,9 @@ export interface ComponentInfoProvider {
 
 // TODO: seems kind of heavy
 export function IsValidPortList(info: ComponentInfo, ports: Schema.Port[]): boolean {
-    // Count ports in each group
-    const countMap = new Map<string, number>();
-    ports.forEach(({ group }) =>
-        countMap.set(group, (countMap.get(group) ?? 0) + 1));
-
-    // Convert map to record
     const counts = {} as Record<string, number>;
-    countMap.forEach((v, k) => counts[k] = v);
-
+    ports.forEach(({ group }) =>
+        counts[group] = (counts[group] ?? 0) + 1);
     return info.isValidPortConfig({ counts });
 }
 

--- a/src/app/core/internal/impl/HistoryManager.ts
+++ b/src/app/core/internal/impl/HistoryManager.ts
@@ -1,4 +1,4 @@
-import { CircuitOp, InvertMultiOp, MultiOp } from "./CircuitOps";
+import {CircuitOp, InvertMultiOp, MultiOp} from "./CircuitOps";
 
 
 class MultiOpStack {
@@ -25,8 +25,8 @@ class MultiOpStack {
 
 export class HistoryManager {
 
-    private undoStack: MultiOpStack;
-    private redoStack: MultiOpStack;
+    private readonly undoStack: MultiOpStack;
+    private readonly redoStack: MultiOpStack;
 
     public constructor() {
         this.undoStack = new MultiOpStack();
@@ -41,22 +41,20 @@ export class HistoryManager {
 
     // Returns a MultiOp that undoes the most recent MultiOp
     public undo(): MultiOp | undefined {
-        let op = this.undoStack.pop();
-        if (op !== undefined) {
-            this.redoStack.push(op);
-            return InvertMultiOp(op);
-        }
-        return undefined;
+        const op = this.undoStack.pop();
+        if (!op)
+            return undefined;
+        this.redoStack.push(op);
+        return InvertMultiOp(op);
     }
 
     // Returns a MultiOp that re-does the most recently undone MultiOp
     public redo(): MultiOp | undefined {
-        let op = this.redoStack.pop();
-        if (op !== undefined) {
-            this.undoStack.push(op);
-            return op;
-        }
-        return undefined;
+        const op = this.redoStack.pop();
+        if (!op)
+            return undefined;
+        this.undoStack.push(op);
+        return op;
     }
 
 }

--- a/src/app/core/internal/impl/HistoryManager.ts
+++ b/src/app/core/internal/impl/HistoryManager.ts
@@ -1,5 +1,62 @@
+import { CircuitOp, InvertMultiOp, MultiOp } from "./CircuitOps";
 
+
+class MultiOpStack {
+    private stack: MultiOp[];
+
+    public push(op: CircuitOp | MultiOp): void {
+        if (op.kind === "MultiOp")
+            this.stack.push(op);
+        else
+            this.stack.push({ kind: "MultiOp", ops: [op] });
+    }
+    public pop(): MultiOp | undefined {
+        return this.stack.pop();
+    }
+
+    public clear(): void {
+        this.stack = [];
+    }
+
+    public get length(): number {
+        return this.stack.length;
+    }
+}
 
 export class HistoryManager {
+
+    private undoStack: MultiOpStack;
+    private redoStack: MultiOpStack;
+
+    public constructor() {
+        this.undoStack = new MultiOpStack();
+        this.redoStack = new MultiOpStack();
+    }
+
+    public push(op: CircuitOp | MultiOp): void {
+        if (this.redoStack.length > 0)
+            this.redoStack.clear();
+        this.undoStack.push(op);
+    }
+
+    // Returns a MultiOp that undoes the most recent MultiOp
+    public undo(): MultiOp | undefined {
+        let op = this.undoStack.pop();
+        if (op !== undefined) {
+            this.redoStack.push(op);
+            return InvertMultiOp(op);
+        }
+        return undefined;
+    }
+
+    // Returns a MultiOp that re-does the most recently undone MultiOp
+    public redo(): MultiOp | undefined {
+        let op = this.redoStack.pop();
+        if (op !== undefined) {
+            this.undoStack.push(op);
+            return op;
+        }
+        return undefined;
+    }
 
 }

--- a/src/app/core/public/api/impl/Circuit.ts
+++ b/src/app/core/public/api/impl/Circuit.ts
@@ -13,31 +13,40 @@ import {Wire}      from "../Wire";
 
 export class CircuitImpl implements Circuit {
     protected circuit: CircuitInternal;
+
+    // Moved from CircuitInternal
+    protected readonly selections: SelectionsManager;
+    public isLocked: boolean;
+
     protected view: CircuitView;
 
     public constructor(canvas: HTMLCanvasElement) {
-        this.circuit = new CircuitInternal();
+        this.circuit = new CircuitInternal(NewExampleComponentInfoProvider());
         this.view = new CircuitView(this.circuit, canvas);
+
+        this.selections = new SelectionsManager();
+        this.isLocked = false;
     }
 
     // Transactions.  All ops between a begin/commit pair are applied atomically (For collaborative editing, undo/redo)
     // All queries within a transaction are coherent.
     // All ops outside begin/commit are applied individually
     public beginTransaction(): void {
-        throw new Error("Unimplemented");
+        this.circuit.beginTransaction();
     }
     public commitTransaction(): void {
-        throw new Error("Unimplemented");
+        this.circuit.commitTransaction();
     }
     public cancelTransaction(): void {
-        throw new Error("Unimplemented");
+        this.circuit.cancelTransaction();
     }
 
     public set locked(val: boolean) {
         throw new Error("Unimplemented");
     }
     public get locked(): boolean {
-        return this.circuit.isLocked;
+        // TODO: Decide which level to enforce this at.  Is it serialized?
+        throw new Error("Unimplemented");
     }
 
     public set simEnabled(val: boolean) {

--- a/src/app/core/public/api/impl/Circuit.ts
+++ b/src/app/core/public/api/impl/Circuit.ts
@@ -1,6 +1,8 @@
-import {CircuitInternal} from "core/internal/impl/CircuitInternal";
-import {DebugOptions}    from "core/internal/impl/DebugOptions";
-import {CircuitView}     from "core/internal/view/CircuitView";
+import {CircuitInternal}                 from "core/internal/impl/CircuitInternal";
+import {NewExampleComponentInfoProvider} from "core/internal/impl/ComponentInfo";
+import {DebugOptions}                    from "core/internal/impl/DebugOptions";
+import {SelectionsManager}               from "core/internal/impl/SelectionsManager";
+import {CircuitView}                     from "core/internal/view/CircuitView";
 
 import {Rect}      from "../../utils/math/Rect";
 import {Vector}    from "../../utils/math/Vector";

--- a/src/app/core/public/api/impl/Component.ts
+++ b/src/app/core/public/api/impl/Component.ts
@@ -1,13 +1,12 @@
-import {Schema}       from "core/schema";
-
+import {Schema} from "core/schema";
 
 import {V, Vector}     from "../../utils/math/Vector";
 import {Component}     from "../Component";
 import {ComponentInfo} from "../ComponentInfo";
 import {Port}          from "../Port";
 
-import { BaseObjectImpl } from "./BaseObject";
-import { PortImpl } from "./Port";
+import {BaseObjectImpl} from "./BaseObject";
+import {PortImpl}       from "./Port";
 
 
 export class ComponentImpl extends BaseObjectImpl implements Component {

--- a/src/app/core/public/api/impl/Component.ts
+++ b/src/app/core/public/api/impl/Component.ts
@@ -1,4 +1,3 @@
-import {GetDebugInfo} from "core/internal/utils/Debug";
 import {Schema}       from "core/schema";
 
 
@@ -7,19 +6,17 @@ import {Component}     from "../Component";
 import {ComponentInfo} from "../ComponentInfo";
 import {Port}          from "../Port";
 
-import {BaseObjectImpl} from "./BaseObject";
-import {PortImpl}       from "./Port";
+import { BaseObjectImpl } from "./BaseObject";
+import { PortImpl } from "./Port";
 
 
 export class ComponentImpl extends BaseObjectImpl implements Component {
     public readonly baseKind = "Component";
 
     protected getObj(): Schema.Component {
-        const obj = this.circuit.getObjByID(this.id);
+        const obj = this.circuit.getCompByID(this.id);
         if (!obj)
             throw new Error(`API Component: Attempted to get component with ID ${this.id} could not find it!`);
-        if (obj.baseKind !== "Component")
-            throw new Error(`API Component: Attempted to get component with ID ${this.id} but received ${GetDebugInfo(obj)} instead!`);
         return obj;
     }
 


### PR DESCRIPTION
Filled out parts of `CircuitInternal` to facilitate history, undo/redo, transactions.  Added a couple public functions to provide a front-end to this "CircuitOp" model for mutating the circuit.

Added sample `CircuitInfo` type so `CircuitInternal` is generic across digital/analog and doesn't need knowledge of specific components.

Future work:
- Decide on an interface for providing events/callbacks from this mutation system.