### PR TITLE
[4] Added rotate tool and selection box tool

### DIFF
--- a/src/app/core/internal/impl/SelectionsManager.ts
+++ b/src/app/core/internal/impl/SelectionsManager.ts
@@ -41,6 +41,10 @@ export class SelectionsManager extends Observable<SelectionEvent> {
         return [...this.selections];
     }
 
+    public length(): number {
+        return this.selections.size;
+    }
+
     public clear(): void {
         // TODO(callac5): See above for reference
         throw new Error("Unimplemented");

--- a/src/app/core/internal/view/rendering/Style.ts
+++ b/src/app/core/internal/view/rendering/Style.ts
@@ -7,4 +7,5 @@ export interface StrokeStyle {
 export interface Style {
     stroke?: StrokeStyle;
     fill?: string | CanvasGradient;
+    alpha?: number;
 }

--- a/src/app/core/internal/view/rendering/prims/BaseShapePrim.ts
+++ b/src/app/core/internal/view/rendering/prims/BaseShapePrim.ts
@@ -31,6 +31,8 @@ export abstract class BaseShapePrim implements Prim {
             ctx.strokeStyle = this.style.stroke.color;
             ctx.lineWidth = this.style.stroke.size;
         }
+        if (this.style.alpha !== undefined)
+            ctx.globalAlpha = this.style.alpha;
 
         ctx.save();
 
@@ -48,6 +50,10 @@ export abstract class BaseShapePrim implements Prim {
         ctx.closePath();
 
         ctx.restore();
+
+        // Reset alpha if we set it
+        if (this.style.alpha !== undefined)
+            ctx.globalAlpha = 1;
     }
 
     public updateStyle(style: Style): void {

--- a/src/app/core/internal/view/rendering/prims/CircleSectorPrim.ts
+++ b/src/app/core/internal/view/rendering/prims/CircleSectorPrim.ts
@@ -41,7 +41,6 @@ export class CircleSectorPrim extends BaseShapePrim {
         let da = (a1 - a0) % (2*Math.PI);
         if (da < 0)
             da += 2*Math.PI;
-        // Flip angles since y-axis is flipped
-        ctx.arc(x, y, radius, 2*Math.PI - a0, 2*Math.PI - a1, da <= Math.PI);
+        ctx.arc(x, y, radius, a0, a1, da > Math.PI);
     }
 }

--- a/src/app/core/public/api/BaseObject.ts
+++ b/src/app/core/public/api/BaseObject.ts
@@ -11,6 +11,9 @@ export interface BaseObject {
     isSelected: boolean;
     zIndex: number;
 
+    select(): void;
+    deselect(): void;
+
     exists(): boolean;
 
     setProp(key: string, val: Prop): void;

--- a/src/app/core/public/api/Circuit.ts
+++ b/src/app/core/public/api/Circuit.ts
@@ -2,8 +2,12 @@ import {Vector} from "Vector";
 
 import {Rect} from "math/Rect";
 
+import {GUID} from "core/schema/GUID";
+
 import {DebugOptions} from "core/internal/impl/DebugOptions";
-import {GUID}         from "core/schema/GUID";
+
+import {RenderHelper}  from "core/internal/view/rendering/RenderHelper";
+import {RenderOptions} from "core/internal/view/rendering/RenderOptions";
 
 import {Camera}        from "./Camera";
 import {Component}     from "./Component";
@@ -11,8 +15,7 @@ import {ComponentInfo} from "./ComponentInfo";
 import {Obj}           from "./Obj";
 import {Port}          from "./Port";
 import {Wire}          from "./Wire";
-import {RenderHelper}  from "core/internal/view/rendering/RenderHelper";
-import {RenderOptions} from "core/internal/view/rendering/RenderOptions";
+import {Selections}    from "./Selections";
 
 
 export type {CircuitMetadata} from "core/schema/CircuitMetadata";
@@ -41,7 +44,7 @@ export interface Circuit {
     pickWireAt(pt: Vector, space?: Vector.Spaces): Wire | undefined;
     pickPortAt(pt: Vector, space?: Vector.Spaces): Port | undefined;
     pickObjRange(bounds: Rect): Obj[];
-    readonly selectedObjs: Obj[];
+    readonly selections: Selections;
 
     getComponent(id: GUID): Component | undefined;
     getWire(id: GUID): Wire | undefined;

--- a/src/app/core/public/api/Selections.ts
+++ b/src/app/core/public/api/Selections.ts
@@ -1,0 +1,12 @@
+import {Component} from "./Component";
+import {Obj}       from "./Obj";
+
+
+export interface Selections {
+    readonly length: number;
+    readonly isEmpty: boolean;
+
+    readonly components: Component[];
+
+    every(condition: (obj: Obj, i: number, arr: Obj[]) => boolean): boolean;
+}

--- a/src/app/core/public/api/Utilities.ts
+++ b/src/app/core/public/api/Utilities.ts
@@ -1,0 +1,9 @@
+import {Component} from "./Component";
+import {Obj}       from "./Obj";
+import {Port}      from "./Port";
+import {Wire}      from "./Wire";
+
+
+export const isObjComponent = (obj: Obj): obj is Component => (obj.baseKind === "Component");
+export const isObjWire      = (obj: Obj): obj is Wire      => (obj.baseKind === "Wire");
+export const isObjPort      = (obj: Obj): obj is Port      => (obj.baseKind === "Port");

--- a/src/app/core/public/api/impl/BaseObject.ts
+++ b/src/app/core/public/api/impl/BaseObject.ts
@@ -20,8 +20,8 @@ export abstract class BaseObjectImpl<State extends CircuitState = CircuitState> 
     protected get internal(): CircuitInternal {
         return this.circuit.circuit;
     }
-    protected get selections(): SelectionsManager {
-        return this.circuit.selections;
+    protected get selectionsManager(): SelectionsManager {
+        return this.circuit.selectionsManager;
     }
 
     public get kind(): string {
@@ -38,12 +38,12 @@ export abstract class BaseObjectImpl<State extends CircuitState = CircuitState> 
 
     public set isSelected(val: boolean) {
         if (val)
-            this.selections.select(this.objID);
+            this.selectionsManager.select(this.objID);
         else
-            this.selections.deselect(this.objID);
+            this.selectionsManager.deselect(this.objID);
     }
     public get isSelected(): boolean {
-        return this.selections.has(this.objID);
+        return this.selectionsManager.has(this.objID);
     }
 
     public set zIndex(val: number) {

--- a/src/app/core/public/api/impl/BaseObject.ts
+++ b/src/app/core/public/api/impl/BaseObject.ts
@@ -53,6 +53,13 @@ export abstract class BaseObjectImpl<State extends CircuitState = CircuitState> 
         throw new Error("Unimplemented");
     }
 
+    public select(): void {
+        this.isSelected = true;
+    }
+    public deselect(): void {
+        this.isSelected = false;
+    }
+
     public exists(): boolean {
         return !!this.internal.getObjByID(this.objID);
     }

--- a/src/app/core/public/api/impl/Circuit.ts
+++ b/src/app/core/public/api/impl/Circuit.ts
@@ -19,6 +19,8 @@ import {CreateDrawingFromSVG} from "svg2canvas";
 import {CameraImpl}           from "./Camera";
 import {RenderHelper}         from "core/internal/view/rendering/RenderHelper";
 import {RenderOptions}        from "core/internal/view/rendering/RenderOptions";
+import {Selections}           from "../Selections";
+import {SelectionsImpl}       from "./Selections";
 
 
 export abstract class CircuitImpl<
@@ -29,19 +31,19 @@ export abstract class CircuitImpl<
     public circuit: CircuitInternal;
     public view: CircuitView;
 
-    public selections: SelectionsManager;
+    public selectionsManager: SelectionsManager;
 
     public isLocked: boolean;
 
     public constructor(
         circuit: CircuitInternal,
         view: CircuitView,
-        selections: SelectionsManager
+        selectionsManager: SelectionsManager
     ) {
         this.circuit = circuit;
         this.view = view;
 
-        this.selections = selections;
+        this.selectionsManager = selectionsManager;
 
         this.isLocked = false;
     }
@@ -139,10 +141,8 @@ export abstract class CircuitImpl<
         throw new Error("Unimplemented");
     }
 
-    public get selectedObjs(): Obj[] {
-        return this.selections.get()
-               .map((id) => this.getObj(id))
-               .filter((obj) => (obj !== undefined)) as Obj[];
+    public get selections(): Selections {
+        return new SelectionsImpl(this);
     }
 
     public getComponent(id: string): ComponentT | undefined {
@@ -178,9 +178,9 @@ export abstract class CircuitImpl<
     }
 
     public selectionsMidpoint(space: Vector.Spaces): Vector {
-        const allComponents = this.selections.get()
-                              .map((id) => this.getComponent(id))
-                              .filter((comp) => (comp !== undefined)) as Component[];
+        const allComponents = this.selectionsManager.get()
+            .map((id) => this.getComponent(id))
+            .filter((comp) => (comp !== undefined)) as Component[];
 
         // Case: no components are selected
         if (allComponents.length === 0)

--- a/src/app/core/public/api/impl/CircuitState.ts
+++ b/src/app/core/public/api/impl/CircuitState.ts
@@ -21,7 +21,7 @@ export type CircuitState<
     //  even when there isn't a canvas/images loaded.
     view?: CircuitView;
 
-    selections: SelectionsManager;
+    selectionsManager: SelectionsManager;
 
     isLocked: boolean;
 

--- a/src/app/core/public/api/impl/Selections.ts
+++ b/src/app/core/public/api/impl/Selections.ts
@@ -1,0 +1,38 @@
+import {Component}    from "../Component";
+import {Obj}          from "../Obj";
+import {Selections}   from "../Selections";
+import {CircuitState} from "./CircuitState";
+
+
+export class SelectionsImpl implements Selections {
+    protected state: CircuitState;
+
+    public constructor(state: CircuitState) {
+        this.state = state;
+    }
+
+    private get selections() {
+        return this.state.selectionsManager.get();
+    }
+    private get doc() {
+        return this.state.circuit.doc;
+    }
+
+    public get length(): number {
+        return this.state.selectionsManager.length();
+    }
+    public get isEmpty(): boolean {
+        return (this.length > 0);
+    }
+
+    public get components(): Component[] {
+        return this.selections.filter((id) => (this.doc.hasComp(id)))
+            .map((id) => this.state.constructComponent(id));
+    }
+
+    public every(condition: (obj: Obj, i: number, arr: Obj[]) => boolean): boolean {
+        return this.selections
+            .map((id) => this.state.getObj(id)!)
+            .every(condition);
+    }
+}

--- a/src/app/core/public/index.ts
+++ b/src/app/core/public/index.ts
@@ -1,4 +1,3 @@
-
 export * from "core/schema/GUID";
 export * from "core/schema/Prop";
 
@@ -8,3 +7,6 @@ export * from "./api/Wire";
 export * from "./api/Port";
 export * from "./api/Obj";
 export * from "./api/Circuit";
+export * from "./api/Camera";
+export * from "./api/Selections";
+export * from "./api/Utilities";

--- a/src/site/pages/digital/src/index.tsx
+++ b/src/site/pages/digital/src/index.tsx
@@ -16,10 +16,12 @@ import {DefaultTool}              from "shared/tools/DefaultTool";
 import {PanTool}                  from "shared/tools/PanTool";
 import {TranslateTool}            from "shared/tools/TranslateTool";
 import {SelectionBoxTool}         from "shared/tools/SelectionBoxTool";
+import {RotateTool}               from "shared/tools/RotateTool";
 import {WiringTool}               from "shared/tools/WiringTool";
 import {ZoomHandler}              from "shared/tools/handlers/ZoomHandler";
 import {SelectionHandler}         from "shared/tools/handlers/SelectionHandler";
 import {SelectionBoxToolRenderer} from "shared/tools/renderers/SelectionBoxToolRenderer";
+import {RotateToolRenderer}       from "shared/tools/renderers/RotateToolRenderer";
 
 import {DigitalWiringToolRenderer} from "./tools/renderers/DigitalWiringToolRenderer";
 
@@ -69,8 +71,8 @@ async function Init(): Promise<void> {
         CreateCircuit(),
         {
             defaultTool: new DefaultTool(ZoomHandler, SelectionHandler),
-            tools:       [PanTool, new TranslateTool(), new WiringTool(), new SelectionBoxTool()],
-            renderers:   [new DigitalWiringToolRenderer(), SelectionBoxToolRenderer],
+            tools:       [PanTool, new TranslateTool(), new RotateTool(), new WiringTool(), new SelectionBoxTool()],
+            renderers:   [new DigitalWiringToolRenderer(), SelectionBoxToolRenderer, RotateToolRenderer],
         },
     );
 

--- a/src/site/pages/digital/src/index.tsx
+++ b/src/site/pages/digital/src/index.tsx
@@ -12,12 +12,14 @@ import {storeDesigner} from "shared/utils/hooks/useDesigner";
 
 import {CreateDesigner} from "shared/circuitdesigner";
 
-import {DefaultTool}      from "shared/tools/DefaultTool";
-import {PanTool}          from "shared/tools/PanTool";
-import {TranslateTool}    from "shared/tools/TranslateTool";
-import {WiringTool}       from "shared/tools/WiringTool";
-import {ZoomHandler}      from "shared/tools/handlers/ZoomHandler";
-import {SelectionHandler} from "shared/tools/handlers/SelectionHandler";
+import {DefaultTool}              from "shared/tools/DefaultTool";
+import {PanTool}                  from "shared/tools/PanTool";
+import {TranslateTool}            from "shared/tools/TranslateTool";
+import {SelectionBoxTool}         from "shared/tools/SelectionBoxTool";
+import {WiringTool}               from "shared/tools/WiringTool";
+import {ZoomHandler}              from "shared/tools/handlers/ZoomHandler";
+import {SelectionHandler}         from "shared/tools/handlers/SelectionHandler";
+import {SelectionBoxToolRenderer} from "shared/tools/renderers/SelectionBoxToolRenderer";
 
 import {DigitalWiringToolRenderer} from "./tools/renderers/DigitalWiringToolRenderer";
 
@@ -67,8 +69,8 @@ async function Init(): Promise<void> {
         CreateCircuit(),
         {
             defaultTool: new DefaultTool(ZoomHandler, SelectionHandler),
-            tools:       [PanTool, new TranslateTool(), new WiringTool()],
-            renderers:   [new DigitalWiringToolRenderer()],
+            tools:       [PanTool, new TranslateTool(), new WiringTool(), new SelectionBoxTool()],
+            renderers:   [new DigitalWiringToolRenderer(), SelectionBoxToolRenderer],
         },
     );
 

--- a/src/site/shared/circuitdesigner/CircuitDesigner.ts
+++ b/src/site/shared/circuitdesigner/CircuitDesigner.ts
@@ -1,6 +1,5 @@
 import {Circuit, Obj} from "core/public";
 import {Cursor}       from "shared/utils/input/Cursor";
-import {Vector}       from "Vector";
 
 
 export interface CircuitDesigner<CircuitT extends Circuit = Circuit> {
@@ -9,8 +8,5 @@ export interface CircuitDesigner<CircuitT extends Circuit = Circuit> {
     cursor?: Cursor;
     curPressedObj?: Obj;
 
-    readonly worldMousePos: Vector;
-
     attachCanvas(canvas: HTMLCanvasElement): () => void;
-    detachCanvas(): void;
 }

--- a/src/site/shared/circuitdesigner/CircuitDesigner.ts
+++ b/src/site/shared/circuitdesigner/CircuitDesigner.ts
@@ -1,5 +1,6 @@
 import {Circuit, Obj} from "core/public";
 import {Cursor}       from "shared/utils/input/Cursor";
+import {Vector}       from "Vector";
 
 
 export interface CircuitDesigner<Circ extends Circuit = Circuit> {
@@ -7,4 +8,6 @@ export interface CircuitDesigner<Circ extends Circuit = Circuit> {
 
     cursor?: Cursor;
     curPressedObj?: Obj;
+
+    readonly worldMousePos: Vector;
 }

--- a/src/site/shared/circuitdesigner/impl/CircuitDesigner.ts
+++ b/src/site/shared/circuitdesigner/impl/CircuitDesigner.ts
@@ -11,7 +11,7 @@ import {ToolManager}     from "./ToolManager";
 export interface ToolConfig {
     defaultTool: DefaultTool;
     tools: Tool[];
-    renderers?: Array<ToolRenderer<Tool>>;
+    renderers?: Array<ToolRenderer<Tool | undefined>>;
 }
 
 export class CircuitDesignerImpl<Circ extends Circuit> implements CircuitDesigner<Circ> {
@@ -60,8 +60,12 @@ export class CircuitDesignerImpl<Circ extends Circuit> implements CircuitDesigne
             this.circuit.addRenderCallback(({ renderer, options, circuit }) => {
                 renderers.forEach((toolRenderer) => {
                     const curTool = this.toolManager.curTool;
-                    if (toolRenderer.isActive(curTool))
-                        toolRenderer.render({ renderer, options, circuit, curTool, input: this.inputManager.state });
+                    if (toolRenderer.isActive(curTool)) {
+                        toolRenderer.render({
+                            renderer, options, circuit, curTool,
+                            input: this.inputManager.state,
+                        });
+                    }
                 });
             })
         }
@@ -79,5 +83,9 @@ export class CircuitDesignerImpl<Circ extends Circuit> implements CircuitDesigne
     }
     public set cursor(cursor: Cursor | undefined) {
         this.state.cursor = cursor;
+    }
+
+    public get worldMousePos() {
+        return this.circuit.camera.toWorldPos(this.inputManager.state.mousePos);
     }
 }

--- a/src/site/shared/tools/DefaultTool.ts
+++ b/src/site/shared/tools/DefaultTool.ts
@@ -22,7 +22,7 @@ export class DefaultTool {
 
         if (ev.type === "mousedown") {
             // Find object if we pressed on one
-            designer.curPressedObj = designer.circuit.pickObjAt(ev.state.mousePos, "screen");
+            designer.curPressedObj = designer.circuit.pickObjAt(ev.input.mousePos, "screen");
         } else if (ev.type === "mouseup") {
             designer.curPressedObj = undefined;
         }

--- a/src/site/shared/tools/PanTool.ts
+++ b/src/site/shared/tools/PanTool.ts
@@ -10,10 +10,10 @@ export const PanTool: Tool = {
         //                           or the middle mouse button
         (ev.type === "keydown" && (ev.key === "Alt")) ||
         (ev.type === "mousedrag" && (ev.button === MIDDLE_MOUSE_BUTTON ||
-                                    ev.state.touchCount === 2))
+                                    ev.input.touchCount === 2))
     ),
     shouldDeactivate: (ev) => (
-        (!ev.state.isDragging && !ev.state.isAltKeyDown)
+        (!ev.input.isDragging && !ev.input.isAltKeyDown)
     ),
 
     onActivate:   () => {},
@@ -21,7 +21,7 @@ export const PanTool: Tool = {
 
     onEvent: (ev, { circuit }) => {
         if (ev.type === "mousedrag") {
-            const { x: dx, y: dy } = ev.state.deltaMousePos;
+            const { x: dx, y: dy } = ev.input.deltaMousePos;
             circuit.camera.translate(V(-dx, -dy), "screen");
         }
     },

--- a/src/site/shared/tools/RotateTool.ts
+++ b/src/site/shared/tools/RotateTool.ts
@@ -1,6 +1,6 @@
 import {V, Vector} from "Vector";
 
-import {Circuit, Component} from "core/public";
+import {Circuit, Component, isObjComponent} from "core/public";
 
 import {CircuitDesigner}   from "shared/circuitdesigner/CircuitDesigner";
 import {InputAdapterEvent} from "shared/utils/input/InputAdapterEvent";
@@ -47,8 +47,8 @@ export class RotateTool implements Tool {
         return (
             ev.type === "mousedown" &&
             ev.input.touchCount === 1 &&
-            circuit.selectedObjs.length > 0 &&
-            circuit.selectedObjs.every((obj) => (obj.baseKind === "Component")) &&
+            circuit.selections.isEmpty &&
+            circuit.selections.every(isObjComponent) &&
             this.isOnCircle(ev.input.mousePos, circuit)
         );
     }
@@ -57,7 +57,7 @@ export class RotateTool implements Tool {
     }
 
     public onActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
-        this.components = circuit.selectedObjs as Component[];
+        this.components = circuit.selections.components;
 
         // Get initial angles
         this.curAngles = this.components.map((c) => c.angle);

--- a/src/site/shared/tools/RotateTool.ts
+++ b/src/site/shared/tools/RotateTool.ts
@@ -46,23 +46,23 @@ export class RotateTool implements Tool {
         //  there are ONLY Components being selected
         return (
             ev.type === "mousedown" &&
-            ev.state.touchCount === 1 &&
+            ev.input.touchCount === 1 &&
             circuit.selectedObjs.length > 0 &&
             circuit.selectedObjs.every((obj) => (obj.baseKind === "Component")) &&
-            this.isOnCircle(ev.state.mousePos, circuit)
+            this.isOnCircle(ev.input.mousePos, circuit)
         );
     }
     public shouldDeactivate(ev: InputAdapterEvent): boolean {
         return (ev.type === "mouseup");
     }
 
-    public onActivate(ev: InputAdapterEvent, { circuit, worldMousePos }: CircuitDesigner): void {
+    public onActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         this.components = circuit.selectedObjs as Component[];
 
         // Get initial angles
         this.curAngles = this.components.map((c) => c.angle);
         this.curAroundAngle = 0;
-        this.startAngle = worldMousePos.sub(circuit.selectionsMidpoint("world")).angle();
+        this.startAngle = ev.input.worldMousePos.sub(circuit.selectionsMidpoint("world")).angle();
         this.prevAngle = this.startAngle;
 
         // Start the transaction
@@ -73,20 +73,20 @@ export class RotateTool implements Tool {
         circuit.commitTransaction();
     }
 
-    public onEvent(ev: InputAdapterEvent, { circuit, worldMousePos }: CircuitDesigner): void {
+    public onEvent(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         if (ev.type === "mousedrag") {
             // Get whether z is presesed for independent rotation
-            const isIndependent = ev.state.keysDown.has("z");
+            const isIndependent = ev.input.keysDown.has("z");
 
             const midpoint = circuit.selectionsMidpoint("world");
 
-            const dAngle = worldMousePos.sub(midpoint).angle() - this.prevAngle;
+            const dAngle = ev.input.worldMousePos.sub(midpoint).angle() - this.prevAngle;
 
             // Calculate new and snapped angles
             const newAngles = this.curAngles.map((a) => (a + dAngle));
             const snappedAngles = newAngles
                 .map((a) => (
-                    ev.state.isShiftKeyDown
+                    ev.input.isShiftKeyDown
                     ? (Math.floor(a/ROTATION_SNAP_AMT)*ROTATION_SNAP_AMT)
                     : a
                 ));
@@ -98,7 +98,7 @@ export class RotateTool implements Tool {
                 : this.curAroundAngle + dAngle
             );
             const snappedAroundAngle = (
-                ev.state.isShiftKeyDown
+                ev.input.isShiftKeyDown
                 ? Math.floor(newAroundAngle/ROTATION_SNAP_AMT)*ROTATION_SNAP_AMT
                 : newAroundAngle
             );

--- a/src/site/shared/tools/RotateTool.ts
+++ b/src/site/shared/tools/RotateTool.ts
@@ -3,7 +3,7 @@ import {V, Vector} from "Vector";
 import {Circuit, Component} from "core/public";
 
 import {CircuitDesigner}   from "shared/circuitdesigner/CircuitDesigner";
-import {InputManagerEvent} from "shared/utils/input/InputManagerEvent";
+import {InputAdapterEvent} from "shared/utils/input/InputAdapterEvent";
 
 import {Tool} from "./Tool";
 
@@ -40,7 +40,7 @@ export class RotateTool implements Tool {
         return (ROTATION_CIRCLE_R1 <= d && d <= ROTATION_CIRCLE_R2);
     }
 
-    public shouldActivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): boolean {
+    public shouldActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): boolean {
         // Activate if the user pressed their mouse or finger
         //  down over the "rotation circle" which appears if
         //  there are ONLY Components being selected
@@ -52,11 +52,11 @@ export class RotateTool implements Tool {
             this.isOnCircle(ev.state.mousePos, circuit)
         );
     }
-    public shouldDeactivate(ev: InputManagerEvent): boolean {
+    public shouldDeactivate(ev: InputAdapterEvent): boolean {
         return (ev.type === "mouseup");
     }
 
-    public onActivate(ev: InputManagerEvent, { circuit, worldMousePos }: CircuitDesigner): void {
+    public onActivate(ev: InputAdapterEvent, { circuit, worldMousePos }: CircuitDesigner): void {
         this.components = circuit.selectedObjs as Component[];
 
         // Get initial angles
@@ -69,11 +69,11 @@ export class RotateTool implements Tool {
         circuit.beginTransaction();
     }
 
-    public onDeactivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+    public onDeactivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         circuit.commitTransaction();
     }
 
-    public onEvent(ev: InputManagerEvent, { circuit, worldMousePos }: CircuitDesigner): void {
+    public onEvent(ev: InputAdapterEvent, { circuit, worldMousePos }: CircuitDesigner): void {
         if (ev.type === "mousedrag") {
             // Get whether z is presesed for independent rotation
             const isIndependent = ev.state.keysDown.has("z");

--- a/src/site/shared/tools/RotateTool.ts
+++ b/src/site/shared/tools/RotateTool.ts
@@ -1,0 +1,131 @@
+import {V, Vector} from "Vector";
+
+import {Circuit, Component} from "core/public";
+
+import {CircuitDesigner}   from "shared/circuitdesigner/CircuitDesigner";
+import {InputManagerEvent} from "shared/utils/input/InputManagerEvent";
+
+import {Tool} from "./Tool";
+
+
+export const ROTATION_CIRCLE_RADIUS = 1.5;
+export const ROTATION_CIRCLE_THICKNESS = 0.1;
+
+const ROTATION_SNAP_AMT = Math.PI/4;
+const ROTATION_CIRCLE_THRESHOLD = ROTATION_CIRCLE_THICKNESS + 0.06;
+const ROTATION_CIRCLE_R1 = (ROTATION_CIRCLE_RADIUS - ROTATION_CIRCLE_THRESHOLD) ** 2;
+const ROTATION_CIRCLE_R2 = (ROTATION_CIRCLE_RADIUS + ROTATION_CIRCLE_THRESHOLD) ** 2;
+
+export class RotateTool implements Tool {
+    private components: Component[];
+
+    private curAngles: number[];
+    private curAroundAngle: number;
+    private startAngle: number;
+    private prevAngle: number;
+
+    public constructor() {
+        this.components = [];
+
+        this.curAngles = [];
+        this.curAroundAngle = 0;
+        this.startAngle = 0;
+        this.prevAngle = 0;
+    }
+
+    private isOnCircle(pos: Vector, circuit: Circuit): boolean {
+        const worldPos = circuit.camera.toWorldPos(pos);
+        const d = worldPos.sub(circuit.selectionsMidpoint("world")).len2();
+
+        return (ROTATION_CIRCLE_R1 <= d && d <= ROTATION_CIRCLE_R2);
+    }
+
+    public shouldActivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): boolean {
+        // Activate if the user pressed their mouse or finger
+        //  down over the "rotation circle" which appears if
+        //  there are ONLY Components being selected
+        return (
+            ev.type === "mousedown" &&
+            ev.state.touchCount === 1 &&
+            circuit.selectedObjs.length > 0 &&
+            circuit.selectedObjs.every((obj) => (obj.baseKind === "Component")) &&
+            this.isOnCircle(ev.state.mousePos, circuit)
+        );
+    }
+    public shouldDeactivate(ev: InputManagerEvent): boolean {
+        return (ev.type === "mouseup");
+    }
+
+    public onActivate(ev: InputManagerEvent, { circuit, worldMousePos }: CircuitDesigner): void {
+        this.components = circuit.selectedObjs as Component[];
+
+        // Get initial angles
+        this.curAngles = this.components.map((c) => c.angle);
+        this.curAroundAngle = 0;
+        this.startAngle = worldMousePos.sub(circuit.selectionsMidpoint("world")).angle();
+        this.prevAngle = this.startAngle;
+
+        // Start the transaction
+        circuit.beginTransaction();
+    }
+
+    public onDeactivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+        circuit.commitTransaction();
+    }
+
+    public onEvent(ev: InputManagerEvent, { circuit, worldMousePos }: CircuitDesigner): void {
+        if (ev.type === "mousedrag") {
+            // Get whether z is presesed for independent rotation
+            const isIndependent = ev.state.keysDown.has("z");
+
+            const midpoint = circuit.selectionsMidpoint("world");
+
+            const dAngle = worldMousePos.sub(midpoint).angle() - this.prevAngle;
+
+            // Calculate new and snapped angles
+            const newAngles = this.curAngles.map((a) => (a + dAngle));
+            const snappedAngles = newAngles
+                .map((a) => (
+                    ev.state.isShiftKeyDown
+                    ? (Math.floor(a/ROTATION_SNAP_AMT)*ROTATION_SNAP_AMT)
+                    : a
+                ));
+
+            // Calculate new angle the rotation about the midpoint
+            const newAroundAngle = (
+                isIndependent
+                ? this.curAroundAngle
+                : this.curAroundAngle + dAngle
+            );
+            const snappedAroundAngle = (
+                ev.state.isShiftKeyDown
+                ? Math.floor(newAroundAngle/ROTATION_SNAP_AMT)*ROTATION_SNAP_AMT
+                : newAroundAngle
+            );
+
+            // Calculate new, snapped positions
+            const snappedPositions = this.components
+                .map((c) => V(c.x, c.y))
+                .map((v) => v.rotate(snappedAroundAngle, midpoint));
+
+            this.components.forEach((c, i) => {
+                c.pos = snappedPositions[i];
+                c.angle = snappedAngles[i];
+            })
+
+            this.curAngles = newAngles;
+            this.curAroundAngle = newAroundAngle;
+
+            this.prevAngle += dAngle;
+
+            circuit.forceRedraw();
+        }
+    }
+
+    public getStartAngle() {
+        return this.startAngle;
+    }
+    public getPrevAngle() {
+        return this.prevAngle;
+    }
+}

--- a/src/site/shared/tools/SelectionBoxTool.ts
+++ b/src/site/shared/tools/SelectionBoxTool.ts
@@ -1,0 +1,83 @@
+import {V} from "Vector";
+
+import {Rect} from "math/Rect";
+
+import {CircuitDesigner}   from "shared/circuitdesigner/CircuitDesigner";
+import {InputManagerEvent} from "shared/utils/input/InputManagerEvent";
+
+import {Tool} from "./Tool";
+
+
+export class SelectionBoxTool implements Tool {
+    private rect: Rect;
+
+    public constructor() {
+        this.rect = new Rect(V(), V());
+    }
+
+    public shouldActivate(ev: InputManagerEvent, { curPressedObj }: CircuitDesigner): boolean {
+        // Activate if the user began dragging on empty canvas
+        return (
+            ev.type === "mousedrag" &&
+            ev.state.touchCount === 1 &&
+            curPressedObj === undefined
+        );
+    }
+    public shouldDeactivate(ev: InputManagerEvent): boolean {
+        return (ev.type === "mouseup");
+    }
+
+    public onActivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+        this.rect = Rect.FromPoints(
+            circuit.camera.toWorldPos(ev.state.mouseDownPos),
+            circuit.camera.toWorldPos(ev.state.mousePos),
+        );
+    }
+
+    public onDeactivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+        // Find all objects within the selection box
+        const objs = circuit.pickObjRange(this.rect);
+
+        const deselectAll = (!ev.state.isShiftKeyDown && circuit.selectedObjs.length > 0);
+
+        // If nothing was clicked, check if we should deselect and exit
+        if (objs.length === 0) {
+            // Clear selections if not holding shift
+            if (deselectAll)
+                circuit.clearSelections();
+            return;
+        }
+
+        // If the user selects a group of objects, we want to only select the components
+        //  and ignore any ports that may have also been selected. We only want to
+        //  select Ports if they user only selected ports
+        const nonPortObjs = objs.filter((o) => (o.baseKind !== "Port"));
+
+        // If there are no non-port objects, then `objects` has all the ports and select them.
+        // Otherwise, select just the non-port objects.
+        const objsToSelect = ((nonPortObjs.length === 0) ? objs : nonPortObjs);
+
+        circuit.beginTransaction();
+
+        if (deselectAll)
+            circuit.clearSelections();
+        objsToSelect.forEach((o) => o.select());
+
+        circuit.commitTransaction();
+    }
+
+    public onEvent(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+        if (ev.type === "mousedrag") {
+            this.rect = Rect.FromPoints(
+                circuit.camera.toWorldPos(ev.state.mouseDownPos),
+                circuit.camera.toWorldPos(ev.state.mousePos),
+            );
+
+            circuit.forceRedraw();
+        }
+    }
+
+    public getBounds(): Rect {
+        return this.rect;
+    }
+}

--- a/src/site/shared/tools/SelectionBoxTool.ts
+++ b/src/site/shared/tools/SelectionBoxTool.ts
@@ -19,7 +19,7 @@ export class SelectionBoxTool implements Tool {
         // Activate if the user began dragging on empty canvas
         return (
             ev.type === "mousedrag" &&
-            ev.state.touchCount === 1 &&
+            ev.input.touchCount === 1 &&
             curPressedObj === undefined
         );
     }
@@ -29,8 +29,8 @@ export class SelectionBoxTool implements Tool {
 
     public onActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         this.rect = Rect.FromPoints(
-            circuit.camera.toWorldPos(ev.state.mouseDownPos),
-            circuit.camera.toWorldPos(ev.state.mousePos),
+            circuit.camera.toWorldPos(ev.input.mouseDownPos),
+            circuit.camera.toWorldPos(ev.input.mousePos),
         );
     }
 
@@ -38,7 +38,7 @@ export class SelectionBoxTool implements Tool {
         // Find all objects within the selection box
         const objs = circuit.pickObjRange(this.rect);
 
-        const deselectAll = (!ev.state.isShiftKeyDown && circuit.selectedObjs.length > 0);
+        const deselectAll = (!ev.input.isShiftKeyDown && circuit.selectedObjs.length > 0);
 
         // If nothing was clicked, check if we should deselect and exit
         if (objs.length === 0) {
@@ -69,8 +69,8 @@ export class SelectionBoxTool implements Tool {
     public onEvent(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         if (ev.type === "mousedrag") {
             this.rect = Rect.FromPoints(
-                circuit.camera.toWorldPos(ev.state.mouseDownPos),
-                circuit.camera.toWorldPos(ev.state.mousePos),
+                circuit.camera.toWorldPos(ev.input.mouseDownPos),
+                circuit.camera.toWorldPos(ev.input.mousePos),
             );
 
             circuit.forceRedraw();

--- a/src/site/shared/tools/SelectionBoxTool.ts
+++ b/src/site/shared/tools/SelectionBoxTool.ts
@@ -38,7 +38,7 @@ export class SelectionBoxTool implements Tool {
         // Find all objects within the selection box
         const objs = circuit.pickObjRange(this.rect);
 
-        const deselectAll = (!ev.input.isShiftKeyDown && circuit.selectedObjs.length > 0);
+        const deselectAll = (!ev.input.isShiftKeyDown && circuit.selections.length > 0);
 
         // If nothing was clicked, check if we should deselect and exit
         if (objs.length === 0) {

--- a/src/site/shared/tools/SelectionBoxTool.ts
+++ b/src/site/shared/tools/SelectionBoxTool.ts
@@ -3,7 +3,7 @@ import {V} from "Vector";
 import {Rect} from "math/Rect";
 
 import {CircuitDesigner}   from "shared/circuitdesigner/CircuitDesigner";
-import {InputManagerEvent} from "shared/utils/input/InputManagerEvent";
+import {InputAdapterEvent} from "shared/utils/input/InputAdapterEvent";
 
 import {Tool} from "./Tool";
 
@@ -15,7 +15,7 @@ export class SelectionBoxTool implements Tool {
         this.rect = new Rect(V(), V());
     }
 
-    public shouldActivate(ev: InputManagerEvent, { curPressedObj }: CircuitDesigner): boolean {
+    public shouldActivate(ev: InputAdapterEvent, { curPressedObj }: CircuitDesigner): boolean {
         // Activate if the user began dragging on empty canvas
         return (
             ev.type === "mousedrag" &&
@@ -23,18 +23,18 @@ export class SelectionBoxTool implements Tool {
             curPressedObj === undefined
         );
     }
-    public shouldDeactivate(ev: InputManagerEvent): boolean {
+    public shouldDeactivate(ev: InputAdapterEvent): boolean {
         return (ev.type === "mouseup");
     }
 
-    public onActivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+    public onActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         this.rect = Rect.FromPoints(
             circuit.camera.toWorldPos(ev.state.mouseDownPos),
             circuit.camera.toWorldPos(ev.state.mousePos),
         );
     }
 
-    public onDeactivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+    public onDeactivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         // Find all objects within the selection box
         const objs = circuit.pickObjRange(this.rect);
 
@@ -66,7 +66,7 @@ export class SelectionBoxTool implements Tool {
         circuit.commitTransaction();
     }
 
-    public onEvent(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+    public onEvent(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         if (ev.type === "mousedrag") {
             this.rect = Rect.FromPoints(
                 circuit.camera.toWorldPos(ev.state.mouseDownPos),

--- a/src/site/shared/tools/TranslateTool.ts
+++ b/src/site/shared/tools/TranslateTool.ts
@@ -51,10 +51,10 @@ export class TranslateTool implements Tool {
         //  So instead mousemove is used and whether or not left mouse is still pressed is
         //  handled within the activation and deactivation of this tool.
         if (ev.type === "mousemove") {
-            const snapToGrid = ev.state.isShiftKeyDown;
-            const snapToConnections = !ev.state.isShiftKeyDown;
+            const snapToGrid = ev.input.isShiftKeyDown;
+            const snapToConnections = !ev.input.isShiftKeyDown;
 
-            const dPos = ev.state.deltaMousePos.scale(V(circuit.camera.zoom, -circuit.camera.zoom));
+            const dPos = ev.input.deltaMousePos.scale(V(circuit.camera.zoom, -circuit.camera.zoom));
 
             this.components.forEach((c) => {
                 let pos = V(c.x, c.y).add(dPos);

--- a/src/site/shared/tools/TranslateTool.ts
+++ b/src/site/shared/tools/TranslateTool.ts
@@ -33,7 +33,7 @@ export class TranslateTool implements Tool {
         //  then translate all of the selected objects
         //  otherwise, just translate the pressed object
         this.components = (!curPressedObj || curPressedObj.isSelected)
-            ? (circuit.selectedObjs.filter((o) => (o.baseKind === "Component"))) as Component[]
+            ? circuit.selections.components
             : [curPressedObj as Component];
 
         circuit.beginTransaction();

--- a/src/site/shared/tools/WiringTool.ts
+++ b/src/site/shared/tools/WiringTool.ts
@@ -18,7 +18,7 @@ export const WIRING_PORT_SELECT_RADIUS = 0.34;
 export class WiringTool implements Tool {
     protected curPort: Port | undefined;
 
-    /** Field to help differentiate between this tool when activated with a click vs drag */
+    /** Field to help differentiate between this tool when activated with a click vs drag. */
     protected stateType: "clicked" | "dragged" | undefined;
 
     /**
@@ -68,10 +68,10 @@ export class WiringTool implements Tool {
         // Activate if the user drags or clicks on a port
         return (
             (
-                (ev.type === "mousedown" && ev.button === LEFT_MOUSE_BUTTON && ev.state.touchCount === 1) ||
+                (ev.type === "mousedown" && ev.button === LEFT_MOUSE_BUTTON && ev.input.touchCount === 1) ||
                 (ev.type === "click")
             )
-            && (this.findPort(ev.state.mousePos, circuit) !== undefined)
+            && (this.findPort(ev.input.mousePos, circuit) !== undefined)
         );
     }
     public shouldDeactivate(ev: InputAdapterEvent): boolean {
@@ -85,13 +85,13 @@ export class WiringTool implements Tool {
     }
 
     public onActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
-        this.curPort = this.findPort(ev.state.mousePos, circuit);
+        this.curPort = this.findPort(ev.input.mousePos, circuit);
 
         this.stateType = (ev.type === "click" ? "clicked" : "dragged");
     }
 
     public onDeactivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
-        const port2 = this.findPort(ev.state.mousePos, circuit, this.curPort);
+        const port2 = this.findPort(ev.input.mousePos, circuit, this.curPort);
         if (port2) // Connect the ports if we found a second port
             this.curPort!.connectTo(port2);
 

--- a/src/site/shared/tools/WiringTool.ts
+++ b/src/site/shared/tools/WiringTool.ts
@@ -8,7 +8,7 @@ import {Circuit, Port} from "core/public";
 
 import {CircuitDesigner}                       from "shared/circuitdesigner/CircuitDesigner";
 import {LEFT_MOUSE_BUTTON, RIGHT_MOUSE_BUTTON} from "shared/utils/input/Constants";
-import {InputManagerEvent}                     from "shared/utils/input/InputManagerEvent";
+import {InputAdapterEvent}                     from "shared/utils/input/InputAdapterEvent";
 import {Tool}                                  from "./Tool";
 
 
@@ -64,7 +64,7 @@ export class WiringTool implements Tool {
             .reduce(MinDist).port;
     }
 
-    public shouldActivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): boolean {
+    public shouldActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): boolean {
         // Activate if the user drags or clicks on a port
         return (
             (
@@ -74,7 +74,7 @@ export class WiringTool implements Tool {
             && (this.findPort(ev.state.mousePos, circuit) !== undefined)
         );
     }
-    public shouldDeactivate(ev: InputManagerEvent): boolean {
+    public shouldDeactivate(ev: InputAdapterEvent): boolean {
         return (
             (this.stateType === "clicked" && ev.type === "click") ||
             (this.stateType === "dragged" && ev.type === "mouseup") ||
@@ -84,13 +84,13 @@ export class WiringTool implements Tool {
         );
     }
 
-    public onActivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+    public onActivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         this.curPort = this.findPort(ev.state.mousePos, circuit);
 
         this.stateType = (ev.type === "click" ? "clicked" : "dragged");
     }
 
-    public onDeactivate(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+    public onDeactivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         const port2 = this.findPort(ev.state.mousePos, circuit, this.curPort);
         if (port2) // Connect the ports if we found a second port
             this.curPort!.connectTo(port2);
@@ -98,7 +98,7 @@ export class WiringTool implements Tool {
         this.curPort = undefined;
     }
 
-    public onEvent(ev: InputManagerEvent, { circuit }: CircuitDesigner): void {
+    public onEvent(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         if (ev.type === "mousemove")
             circuit.forceRedraw();
     }

--- a/src/site/shared/tools/handlers/SelectionHandler.ts
+++ b/src/site/shared/tools/handlers/SelectionHandler.ts
@@ -7,7 +7,7 @@ export const SelectionHandler: ToolHandler = {
         if (!(ev.type === "click" && ev.button === LEFT_MOUSE_BUTTON))
             return ToolHandlerResponse.PASS;
 
-        const deselectAll = (!ev.input.isShiftKeyDown && circuit.selectedObjs.length > 0);
+        const deselectAll = (!ev.input.isShiftKeyDown && circuit.selections.length > 0);
 
         const obj = circuit.pickObjAt(ev.input.mousePos, "screen");
         if (!obj) {

--- a/src/site/shared/tools/handlers/SelectionHandler.ts
+++ b/src/site/shared/tools/handlers/SelectionHandler.ts
@@ -7,9 +7,9 @@ export const SelectionHandler: ToolHandler = {
         if (!(ev.type === "click" && ev.button === LEFT_MOUSE_BUTTON))
             return ToolHandlerResponse.PASS;
 
-        const deselectAll = (!ev.state.isShiftKeyDown && circuit.selectedObjs.length > 0);
+        const deselectAll = (!ev.input.isShiftKeyDown && circuit.selectedObjs.length > 0);
 
-        const obj = circuit.pickObjAt(ev.state.mousePos, "screen");
+        const obj = circuit.pickObjAt(ev.input.mousePos, "screen");
         if (!obj) {
             // Clear selections if not holding shift
             if (deselectAll) {
@@ -21,7 +21,7 @@ export const SelectionHandler: ToolHandler = {
 
         // TODO[model_refactor_api](leon) - think about how this works w/ ports and WireTool (like in master)
 
-        const shouldSelect = (!ev.state.isShiftKeyDown || !obj.isSelected);
+        const shouldSelect = (!ev.input.isShiftKeyDown || !obj.isSelected);
 
         circuit.beginTransaction();
 

--- a/src/site/shared/tools/renderers/RotateToolRenderer.ts
+++ b/src/site/shared/tools/renderers/RotateToolRenderer.ts
@@ -1,0 +1,45 @@
+import {CirclePrim}       from "core/internal/view/rendering/prims/CirclePrim";
+import {CircleSectorPrim} from "core/internal/view/rendering/prims/CircleSectorPrim";
+
+import {ROTATION_CIRCLE_RADIUS, ROTATION_CIRCLE_THICKNESS, RotateTool} from "../RotateTool";
+
+import {ToolRenderer} from "./ToolRenderer";
+
+
+export const RotateToolRenderer: ToolRenderer<RotateTool | undefined> = {
+    isActive: (curTool): curTool is RotateTool | undefined => (!curTool || curTool instanceof RotateTool),
+
+    render: ({ circuit, renderer, curTool }) => {
+        const pos = circuit.selectionsMidpoint("world");
+
+        const drawOutline = () => {
+            renderer.draw(new CirclePrim(pos, ROTATION_CIRCLE_RADIUS, {
+                stroke: {
+                    color: "#ff0000",
+                    size:  ROTATION_CIRCLE_THICKNESS,
+                },
+                alpha: 0.5,
+            }));
+        }
+
+        const selections = circuit.selectedObjs;
+
+        // If we are in the default tool, draw the rotation circle outline if we have only components selected
+        if (!curTool) {
+            if (selections.length > 0 &&
+                selections.every((o) => (o.baseKind === "Component"))) {
+                drawOutline();
+            }
+            return;
+        }
+
+        // Otherwise rotate tool is active so draw the rotation circle and outline
+        drawOutline();
+
+        const a0 = curTool.getStartAngle(), a1 = curTool.getPrevAngle();
+        renderer.draw(new CircleSectorPrim(pos, ROTATION_CIRCLE_RADIUS, [a0, a1], {
+            fill:  "#ffffff",
+            alpha: 0.4,
+        }));
+    },
+}

--- a/src/site/shared/tools/renderers/RotateToolRenderer.ts
+++ b/src/site/shared/tools/renderers/RotateToolRenderer.ts
@@ -3,7 +3,8 @@ import {CircleSectorPrim} from "core/internal/view/rendering/prims/CircleSectorP
 
 import {ROTATION_CIRCLE_RADIUS, ROTATION_CIRCLE_THICKNESS, RotateTool} from "../RotateTool";
 
-import {ToolRenderer} from "./ToolRenderer";
+import {ToolRenderer}   from "./ToolRenderer";
+import {isObjComponent} from "core/public";
 
 
 export const RotateToolRenderer: ToolRenderer<RotateTool | undefined> = {
@@ -22,14 +23,12 @@ export const RotateToolRenderer: ToolRenderer<RotateTool | undefined> = {
             }));
         }
 
-        const selections = circuit.selectedObjs;
+        const selections = circuit.selections;
 
         // If we are in the default tool, draw the rotation circle outline if we have only components selected
         if (!curTool) {
-            if (selections.length > 0 &&
-                selections.every((o) => (o.baseKind === "Component"))) {
+            if (selections.isEmpty && selections.every((isObjComponent)))
                 drawOutline();
-            }
             return;
         }
 

--- a/src/site/shared/tools/renderers/SelectionBoxToolRenderer.ts
+++ b/src/site/shared/tools/renderers/SelectionBoxToolRenderer.ts
@@ -1,0 +1,24 @@
+import {RectanglePrim} from "core/internal/view/rendering/prims/RectanglePrim";
+import {Transform}     from "math/Transform";
+
+import {SelectionBoxTool} from "../SelectionBoxTool";
+
+import {ToolRenderer} from "./ToolRenderer";
+
+
+export const SelectionBoxToolRenderer: ToolRenderer<SelectionBoxTool> = {
+    isActive: (curTool): curTool is SelectionBoxTool => (curTool instanceof SelectionBoxTool),
+
+    render: ({ renderer, curTool }) => {
+        const rect = curTool.getBounds();
+
+        renderer.draw(new RectanglePrim(Transform.FromRect(rect), {
+            stroke: {
+                color: "#6666ff",
+                size:  0.04,
+            },
+            fill:  "#ffffff",
+            alpha: 0.4,
+        }));
+    },
+}

--- a/src/site/shared/tools/renderers/ToolRenderer.ts
+++ b/src/site/shared/tools/renderers/ToolRenderer.ts
@@ -2,7 +2,7 @@ import {RenderHelper}  from "core/internal/view/rendering/RenderHelper";
 import {RenderOptions} from "core/internal/view/rendering/RenderOptions";
 import {Circuit}       from "core/public";
 
-import {InputManagerState} from "shared/utils/input/InputManagerState";
+import {UserInputState} from "shared/utils/input/UserInputState";
 
 import {Tool} from "../Tool";
 
@@ -14,7 +14,7 @@ export interface ToolRendererProps<T extends Tool | undefined = Tool> {
     circuit: Circuit;
 
     curTool: T;
-    input: InputManagerState;
+    input: UserInputState;
 }
 
 export interface ToolRenderer<T extends Tool | undefined = Tool> {

--- a/src/site/shared/tools/renderers/ToolRenderer.ts
+++ b/src/site/shared/tools/renderers/ToolRenderer.ts
@@ -7,7 +7,7 @@ import {InputManagerState} from "shared/utils/input/InputManagerState";
 import {Tool} from "../Tool";
 
 
-export interface ToolRendererProps<T extends Tool = Tool> {
+export interface ToolRendererProps<T extends Tool | undefined = Tool> {
     renderer: RenderHelper;
     options: RenderOptions;
 
@@ -17,7 +17,7 @@ export interface ToolRendererProps<T extends Tool = Tool> {
     input: InputManagerState;
 }
 
-export interface ToolRenderer<T extends Tool = Tool> {
+export interface ToolRenderer<T extends Tool | undefined = Tool> {
     isActive(curTool?: Tool): curTool is T;
 
     render(props: ToolRendererProps<T>): void;

--- a/src/site/shared/utils/input/InputAdapter.ts
+++ b/src/site/shared/utils/input/InputAdapter.ts
@@ -13,6 +13,7 @@ import {Observable} from "core/utils/Observable";
 import {Key}               from "./Key";
 import {InputAdapterEvent} from "./InputAdapterEvent";
 import {UserInputState}    from "./UserInputState";
+import {Camera}            from "core/public/api/Camera";
 
 
 export class UserInputStateImpl implements UserInputState {
@@ -30,7 +31,11 @@ export class UserInputStateImpl implements UserInputState {
 
     public keysDown: Set<Key>;
 
-    public constructor() {
+    private readonly camera: Camera;
+
+    public constructor(camera: Camera) {
+        this.camera = camera;
+
         this.mouseDownPos = V();
         this.prevMousePos = V();
         this.mousePos = V();
@@ -44,6 +49,10 @@ export class UserInputStateImpl implements UserInputState {
         this.touchCount = 0;
 
         this.keysDown = new Set();
+    }
+
+    public get worldMousePos() {
+        return this.camera.toWorldPos(this.mousePos);
     }
 
     public get deltaMousePos() {
@@ -72,52 +81,38 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
     private readonly dragTime: number;
 
     /** The canvas the user is performing inputs on. */
-    private canvas?: HTMLCanvasElement;
+    private readonly canvas: HTMLCanvasElement;
 
     public state: UserInputStateImpl;
+
+    public readonly cleanup: () => void;
 
     /**
      * Initializes Input with given canvas and dragTime.
      *
+     * @param canvas   The canvas to adapt the inputs of.
+     * @param camera   The camera for the circuit (used to provide world-space input utilities).
      * @param dragTime The minimum length of time a mousedown must last to be considered a drag rather than a click.
      */
-    public constructor(dragTime: number = DRAG_TIME) {
+    public constructor(canvas: HTMLCanvasElement, camera: Camera, dragTime: number = DRAG_TIME) {
         super();
         this.dragTime = dragTime;
-        this.state = new UserInputStateImpl();
-    }
-
-    /**
-     * Set ups event listeners on the given canvas and returns a tear down callback.
-     *
-     * @param canvas The canvas to setup on.
-     * @returns      A callback that tears down the setup event listeners.
-     * @throws If the canvas was already setup and not torn down.
-     */
-    public setupOn(canvas: HTMLCanvasElement): () => void {
-        if (this.canvas)
-            throw new Error("Attempted to setup Input when previously setup! This is undefined behaviour!");
-
         this.canvas = canvas;
+        this.state = new UserInputStateImpl(camera);
 
+        // Setup adapters
         const tearDownKeyboardEvents = this.hookupKeyboardEvents();
         const tearDownMouseEvents    = this.hookupMouseEvents(canvas);
         const tearDownTouchEvents    = this.hookupTouchEvents(canvas);
         const tearDownHammer         = this.setupHammer(canvas);
 
-        this.tearDown = () => {
+        this.cleanup = () => {
             tearDownHammer();
             tearDownTouchEvents();
             tearDownMouseEvents();
             tearDownKeyboardEvents();
-
-            this.canvas = undefined;
         };
-
-        return this.tearDown;
     }
-
-    public tearDown: () => void = () => {};
 
     /**
      * Checks if newKey is a prevented combination of keys.
@@ -192,9 +187,9 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
         }
         const onBlur = () => this.onBlur();
 
-        const onPaste = (ev: ClipboardEvent) => this.publish({ state: this.state, type: "paste", ev });
-        const onCopy  = (ev: ClipboardEvent) => this.publish({ state: this.state, type: "copy",  ev });
-        const onCut   = (ev: ClipboardEvent) => this.publish({ state: this.state, type: "cut",   ev });
+        const onPaste = (ev: ClipboardEvent) => this.publish({ input: this.state, type: "paste", ev });
+        const onCopy  = (ev: ClipboardEvent) => this.publish({ input: this.state, type: "copy",  ev });
+        const onCut   = (ev: ClipboardEvent) => this.publish({ input: this.state, type: "cut",   ev });
 
 
         window.addEventListener("keydown", onKeyDown, false);
@@ -239,7 +234,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
 
         const onContextMenu = (e: MouseEvent) => {
             e.preventDefault();
-            this.publish({ state: this.state, type: "contextmenu" });
+            this.publish({ input: this.state, type: "contextmenu" });
         }
 
         // Mouse events
@@ -312,7 +307,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
         const pinch = new Hammer.Pinch();
         const onPinch = (e: HammerInput) => {
             this.publish({
-                state:  this.state,
+                input:  this.state,
                 type:   "zoom",
                 factor: lastScale/e.scale,
                 pos:    this.state.mousePos,
@@ -359,14 +354,6 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
     }
 
     /**
-     * Resets internal state of the Input.
-     *  Keeps listeners and outer-controlled state.
-     */
-    public reset(): void {
-        this.state = new UserInputStateImpl();
-    }
-
-    /**
      * Sets the given key as down, and calls each Listener on Event "keydown", key.
      *
      * @param key Represents the key being pressed.
@@ -374,7 +361,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
     protected onKeyDown(key: Key): void {
         this.state.keysDown.add(key);
 
-        this.publish({ state: this.state, type: "keydown", key });
+        this.publish({ input: this.state, type: "keydown", key });
     }
     /**
      * Sets the given key as up, and calls each Listener on Event "keyup", key.
@@ -385,7 +372,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
         this.state.keysDown.delete(key);
 
         // call each listener
-        this.publish({ state: this.state, type: "keyup", key });
+        this.publish({ input: this.state, type: "keyup", key });
     }
 
     /**
@@ -402,7 +389,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
         }
 
         // call each listener
-        this.publish({ state: this.state, type: "click", button });
+        this.publish({ input: this.state, type: "click", button });
     }
     /**
      * Calls each Listener on Event "dbclick", button.
@@ -412,7 +399,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
     protected onDoubleClick(button: number): void {
 
         // call each listener
-        this.publish({ state: this.state, type: "dblclick", button });
+        this.publish({ input: this.state, type: "dblclick", button });
     }
 
     /**
@@ -428,7 +415,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
             zoomFactor = 1 / zoomFactor;
 
         this.publish({
-            state:  this.state,
+            input:  this.state,
             type:   "zoom",
             factor: zoomFactor,
             pos:    this.state.mousePos,
@@ -463,7 +450,7 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
         this.state.mousePos = V(this.state.mouseDownPos);
         this.state.mouseDownButton = button;
 
-        this.publish({ state: this.state, type: "mousedown", button });
+        this.publish({ input: this.state, type: "mousedown", button });
     }
     /**
      * Triggered on mouse movement, calculates new mouse position,
@@ -491,12 +478,12 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
 
         if (this.state.isDragging) {
             this.publish({
-                state:  this.state,
+                input:  this.state,
                 type:   "mousedrag",
                 button: this.state.mouseDownButton,
             });
         }
-        this.publish({ state: this.state, type: "mousemove" });
+        this.publish({ input: this.state, type: "mousemove" });
     }
     /**
      * Calls each Listener on Event "mouseup", button
@@ -509,14 +496,14 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
         this.state.isMouseDown = false;
         this.state.mouseDownButton = -1;
 
-        this.publish({ state: this.state, type: "mouseup", button });
+        this.publish({ input: this.state, type: "mouseup", button });
     }
 
     /**
      * Calls each Listener on Event "mouseenter".
      */
     protected onMouseEnter(): void {
-        this.publish({ state: this.state, type: "mouseenter" });
+        this.publish({ input: this.state, type: "mouseenter" });
     }
     /**
      * Calls each Listener on Event "mouseleave".
@@ -526,13 +513,13 @@ export class InputAdapter extends Observable<InputAdapterEvent> {
         this.state.touchCount = 0;
         this.state.isMouseDown = false;
 
-        this.publish({ state: this.state, type: "mouseleave" });
+        this.publish({ input: this.state, type: "mouseleave" });
 
         // call mouse up as well so that
         //  up events get called when the
         //  mouse leaves
         this.publish({
-            state:  this.state,
+            input:  this.state,
             type:   "mouseup",
             button: this.state.mouseDownButton,
         });

--- a/src/site/shared/utils/input/InputAdapterEvent.ts
+++ b/src/site/shared/utils/input/InputAdapterEvent.ts
@@ -5,7 +5,7 @@ import {Key} from "./Key";
 
 
 export interface BaseInputEvent {
-    state: UserInputState;
+    input: UserInputState;
 }
 export interface MouseInputEvent extends BaseInputEvent {
     type: "click" | "dblclick" | "mousedown" | "mousedrag" | "mouseup";

--- a/src/site/shared/utils/input/UserInputState.ts
+++ b/src/site/shared/utils/input/UserInputState.ts
@@ -18,6 +18,8 @@ export interface UserInputState {
     /** A vector representing the change in mouse position. */
     readonly deltaMousePos: Vector;
 
+    readonly worldMousePos: Vector;
+
     /** True if a mousebutton is held down, false otherwise. */
     readonly isMouseDown: boolean;
     /** Represents the mousebutton being pressed (left, middle, right, etc.). */


### PR DESCRIPTION
Most of their implementations are copied from how they have been

Changed how InputAdapter works, so that instead of constructing it once and then setting up/tearing down on it, instead construct it to set it up and then tear it down when necessary and re-construct it to set it up again. Removes need to `!` every access of `canvas` in the InputAdapter, and also removes need to have an optional instance of it in `CircuitDesigner`, instead it's just held locally. 
This does come at the cost of not having an explicit `tearDown` method anymore on `CircuitDesigner` and instead needing to use the callback `tearDown`.