### PR TITLE
Fix Headless Circuits

### DIFF
--- a/src/app/core/internal/view/CircuitView.ts
+++ b/src/app/core/internal/view/CircuitView.ts
@@ -64,6 +64,10 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
 
     public images: CircuitViewAssetManager<SVGDrawing>;
 
+    private readonly dirtyComponents: Set<GUID>;
+    private readonly dirtyWires: Set<GUID>;
+    private readonly dirtyPorts: Set<GUID>;
+
     public constructor(circuit: CircuitInternal, selections: SelectionsManager) {
         super();
 
@@ -89,44 +93,50 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
 
         this.images = new CircuitViewAssetManager();
 
+        this.dirtyComponents = new Set();
+        this.dirtyWires = new Set();
+        this.dirtyPorts = new Set();
+
         this.scheduler.subscribe(() => this.render());
+        this.scheduler.setBlocked(true);
 
         this.circuit.subscribe((ev) => {
-            // TODO[model_refactor_api](leon) - use events
+            // TODO[model_refactor_api](leon) - use events better, i.e. how to we collect the diffs until the next
+            //                                  render cycle or query for the dirty object(s)?
 
-            // update components first
-            for (const compID of circuit.doc.getComponents()) {
-                const comp = circuit.doc.getCompByID(compID).unwrap();
-                this.getAssemblerFor(comp.kind).assemble(comp, ev);
-            }
+            // Mark all added/removed component dirty
+            for (const compID of ev.addedComponents)
+                this.dirtyComponents.add(compID);
+            for (const compID of ev.removedComponents)
+                this.dirtyComponents.add(compID);
 
-            // temporary hack to handle deleting components (and ports)
-            for (const compID of this.componentPrims.keys()) {
-                if (!circuit.doc.hasComp(compID)) {
-                    this.componentPrims.delete(compID);
-                    this.componentTransforms.delete(compID);
-                    this.portPrims.delete(compID);
-                }
-            }
-            for (const portID of this.portPositions.keys()) {
-                if (!circuit.doc.hasPort(portID)) {
-                    this.portPositions.delete(portID);
-                    this.localPortPositions.delete(portID);
-                }
-            }
+            // Mark all components w/ changed ports dirty
+            for (const compID of ev.portsChanged)
+                this.dirtyComponents.add(compID);
 
-            // then update wires
-            for (const wireID of circuit.doc.getWires()) {
-                const wire = circuit.doc.getWireByID(wireID).unwrap();
-                this.getAssemblerFor(wire.kind).assemble(wire, ev);
-            }
+            // Mark all added/removed wires dirty
+            for (const wireID of ev.addedWires)
+                this.dirtyWires.add(wireID);
+            for (const wireID of ev.removedWires)
+                this.dirtyWires.add(wireID);
 
-            // temporary hack to handle deleting wires
-            for (const wireID of this.wirePrims.keys()) {
-                if (!circuit.doc.hasWire(wireID)) {
-                    this.wireCurves.delete(wireID);
-                    this.wirePrims.delete(wireID);
-                }
+            // Mark all changed obj props dirty
+            for (const [id, props] of ev.propsChanged) {
+                if (circuit.doc.hasComp(id)) {
+                    this.dirtyComponents.add(id);
+
+                    // Component transform changed, update connected wires
+                    if (props.has("x") || props.has("y") || props.has("angle")) {
+                        const ports = this.circuit.doc.getPortsForComponent(id);
+                        ports.map((ports) => ports.forEach((portID) => {
+                            this.circuit.doc.getWiresForPort(portID)
+                                .map((wires) => wires.forEach((wireID) => this.dirtyWires.add(wireID)))
+                        }))
+                    }
+                } else if (circuit.doc.hasWire(id))
+                    this.dirtyWires.add(id);
+                else if (circuit.doc.hasPort(id))
+                    this.dirtyPorts.add(id);
             }
 
             this.cameraMat = this.calcCameraMat();
@@ -136,12 +146,58 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
 
         this.selections.subscribe((ev) => {
             ev.selections.forEach((id) => {
-                const obj = circuit.doc.getObjByID(id).unwrap();
-                this.getAssemblerFor(obj.kind).assemble(obj, ev);
+                if (circuit.doc.hasComp(id))
+                    this.dirtyComponents.add(id);
+                else if (circuit.doc.hasWire(id))
+                    this.dirtyWires.add(id);
+                else if (circuit.doc.hasPort(id))
+                    this.dirtyPorts.add(id);
             });
 
             this.scheduler.requestRender();
         });
+    }
+
+    private updateDirtyObjs() {
+        // Update components first
+        for (const compID of this.dirtyComponents) {
+            // If component still exists, update it
+            if (this.circuit.doc.hasComp(compID)) {
+                const comp = this.circuit.doc.getCompByID(compID).unwrap();
+                // TODO[model_refactor_api](leon) - figure out `ev` param
+                this.getAssemblerFor(comp.kind).assemble(comp, {});
+                continue;
+            }
+            // Otherwise, component was deleted so remove it and any associated ports
+            this.componentPrims.delete(compID);
+            this.componentTransforms.delete(compID);
+            this.portPrims.delete(compID);
+        }
+        this.dirtyComponents.clear();
+
+        // Remove any ports that were deleted
+        for (const portID of this.dirtyPorts) {
+            if (!this.circuit.doc.hasPort(portID)) {
+                this.portPositions.delete(portID);
+                this.localPortPositions.delete(portID);
+            }
+        }
+        this.dirtyPorts.clear();
+
+        // Then update wires
+        for (const wireID of this.dirtyWires) {
+            // If wire still exists, update it
+            if (this.circuit.doc.hasWire(wireID)) {
+                const wire = this.circuit.doc.getWireByID(wireID).unwrap();
+                // TODO[model_refactor_api](leon) - figure out `ev` param
+                this.getAssemblerFor(wire.kind).assemble(wire, {});
+                continue;
+            }
+            // Otherwise, wire was deleted so remove it
+            this.wireCurves.delete(wireID);
+            this.wirePrims.delete(wireID);
+        }
+        this.dirtyWires.clear();
     }
 
     protected calcCameraMat() {
@@ -155,6 +211,19 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
     }
     public toScreenPos(pos: Vector): Vector {
         return this.cameraMat.inverse().mul(pos).add(this.renderer.size.scale(0.5));
+    }
+
+    public getPortPos(portID: GUID): Option<PortPos> {
+        if (!this.circuit.doc.hasPort(portID))
+            return None();
+        const port = this.circuit.doc.getPortByID(portID).unwrap();
+        // TODO[model_refactor_api](leon): This is terrible
+        if (this.dirtyComponents.has(port.parent)) {
+            const comp = this.circuit.doc.getCompByID(port.parent).unwrap();
+            this.getAssemblerFor(comp.kind).assemble(comp, {});
+            this.dirtyComponents.delete(port.parent);
+        }
+        return Some(this.portPositions.get(portID)!);
     }
 
     public findNearestObj(pos: Vector, filter: (id: GUID) => boolean = ((_) => true)): Option<GUID> {
@@ -177,6 +246,11 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
     protected abstract getAssemblerFor(kind: string): Assembler;
 
     protected render(): void {
+        if (!this.renderer.canvas)
+            throw new Error("CircuitView: Attempeted Circuit render before a canvas was set!");
+
+        this.updateDirtyObjs();
+
         // Clear canvas
         this.renderer.clear();
 
@@ -237,6 +311,9 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
     }
 
     public setCanvas(canvas?: HTMLCanvasElement) {
+        // Unlock scheduler once a canvas is set
+        this.scheduler.setBlocked(false);
+
         this.renderer.setCanvas(canvas);
     }
 

--- a/src/app/core/internal/view/CircuitView.ts
+++ b/src/app/core/internal/view/CircuitView.ts
@@ -143,10 +143,11 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
                                 .map((wires) => wires.forEach((wireID) => this.dirtyWires.add(wireID)))
                         }))
                     }
-                } else if (circuit.doc.hasWire(id))
+                } else if (circuit.doc.hasWire(id)) {
                     this.dirtyWires.add(id);
-                else if (circuit.doc.hasPort(id))
+                } else if (circuit.doc.hasPort(id)) {
                     this.dirtyPorts.add(id);
+                }
             }
 
             this.cameraMat = this.calcCameraMat();

--- a/src/app/core/internal/view/CircuitView.ts
+++ b/src/app/core/internal/view/CircuitView.ts
@@ -23,6 +23,24 @@ import {DefaultRenderOptions, RenderOptions} from "./rendering/RenderOptions";
 import {RenderScheduler}                     from "./rendering/RenderScheduler";
 
 
+export class CircuitViewAssetManager<T> extends Observable<{ key: string, val: T }> {
+    private readonly assets: Map<string, T>;
+
+    public constructor() {
+        super();
+
+        this.assets = new Map();
+    }
+
+    public get(key: string): T | undefined {
+        return this.assets.get(key);
+    }
+    public set(key: string, val: T) {
+        this.assets.set(key, val);
+        this.publish({ key, val });
+    }
+}
+
 export abstract class CircuitView extends Observable<{ renderer: RenderHelper }> {
     public readonly circuit: CircuitInternal;
     public readonly selections: SelectionsManager;
@@ -43,6 +61,8 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
 
     public wireCurves: Map<GUID, BezierCurve>;
     public wirePrims: Map<GUID, Prims>;
+
+    public images: CircuitViewAssetManager<SVGDrawing>;
 
     public constructor(circuit: CircuitInternal, selections: SelectionsManager) {
         super();
@@ -66,6 +86,8 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
 
         this.wireCurves = new Map();
         this.wirePrims = new Map();
+
+        this.images = new CircuitViewAssetManager();
 
         this.scheduler.subscribe(() => this.render());
 
@@ -212,10 +234,6 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
     public resize(w: number, h: number) {
         // Request a render on resize
         this.scheduler.requestRender();
-    }
-
-    public addImage(imgSrc: string, img: SVGDrawing) {
-        this.options.addImage(imgSrc, img);
     }
 
     public setCanvas(canvas?: HTMLCanvasElement) {

--- a/src/app/core/internal/view/rendering/RenderOptions.ts
+++ b/src/app/core/internal/view/rendering/RenderOptions.ts
@@ -31,19 +31,6 @@ export interface RenderOptions {
     defaultOnColor: string;
     defaultMetastableColor: string;
 
-    addImage(key: string, img: SVGDrawing): void;
-
-    /**
-     * Retrives the SVG with the given key.
-     * Note this will throw an error if the image is not found.
-     *
-     * @param key The key of the SVG.
-     * @throws If the image is not found.
-     */
-    getImage(key: string): SVGDrawing; // TODO[model_refactor_api](leon) - figure out a system to allow SVGDrawings
-                                       //                                  to exist and work w/o the image loading
-                                       //                                  so that views can exist w/o images/canvas
-
     // fillColor(selected: boolean): string;
     // borderColor(selected: boolean): string;
 

--- a/src/app/core/internal/view/rendering/RenderScheduler.ts
+++ b/src/app/core/internal/view/rendering/RenderScheduler.ts
@@ -33,12 +33,20 @@ export class RenderScheduler extends Observable {
      * Request a render frame and add to the queue.
      */
     public requestRender(): void {
+        // Do nothing when blocked
+        if (this.blocked)
+            return;
+
         if (this.queued === 0)
             this.lastFrameId = requestAnimationFrame(() => this.actualRender());
         this.queued++;
     }
 
     public cancel(): void {
+        // Do nothing when blocked
+        if (this.blocked)
+            return;
+
         cancelAnimationFrame(this.lastFrameId);
     }
 

--- a/src/app/core/internal/view/rendering/prims/SVGPrim.ts
+++ b/src/app/core/internal/view/rendering/prims/SVGPrim.ts
@@ -18,7 +18,7 @@ import {RectContains} from "math/MathUtils";
  *  Instead, it is treated as a rectangle around the bounds of the SVG.
  */
 export class SVGPrim implements Prim {
-    protected svg: SVGDrawing;
+    protected svg?: SVGDrawing;
     protected size: Vector;
     protected transform: Transform;
     protected tint?: Color;
@@ -31,7 +31,7 @@ export class SVGPrim implements Prim {
      * @param transform The transform for this SVG, note that the size of the transform is ignored.
      * @param tint      An optional tinting color to apply over the SVG.
      */
-    public constructor(svg: SVGDrawing, size: Vector, transform: Transform, tint?: string) {
+    public constructor(svg: SVGDrawing | undefined, size: Vector, transform: Transform, tint?: string) {
         this.svg = svg;
         this.size = size;
         this.transform = transform;
@@ -45,6 +45,9 @@ export class SVGPrim implements Prim {
         return RectContains(this.transform, pt);
     }
     public render(ctx: CanvasRenderingContext2D): void {
+        if (!this.svg) // Don't draw if the image isn't loaded
+            return;
+
         ctx.save();
 
         const [a,b,c,d,e,f] = this.transform.getMatrix().mat;

--- a/src/app/core/public/api/impl/Camera.ts
+++ b/src/app/core/public/api/impl/Camera.ts
@@ -62,7 +62,7 @@ export class CameraImpl implements Camera {
     }
 
     public zoomTo(zoom: number, pos: Vector): void {
-        const view = this.state.view!;
+        const view = this.state.view;
 
         const pos0 = view.toWorldPos(pos);
         this.zoom = Clamp(this.zoom * zoom, 1e-6, 200);
@@ -70,6 +70,6 @@ export class CameraImpl implements Camera {
     }
 
     public toWorldPos(screenPos: Vector): Vector {
-        return this.state.view!.toWorldPos(screenPos);
+        return this.state.view.toWorldPos(screenPos);
     }
 }

--- a/src/app/core/public/api/impl/Circuit.ts
+++ b/src/app/core/public/api/impl/Circuit.ts
@@ -253,7 +253,7 @@ export abstract class CircuitImpl<
                 const drawing = CreateDrawingFromSVG(svgXML, {});
                 if (!drawing)
                     throw new Error(`Failed to create drawing for svg: img/items/${src}`);
-                this.view.addImage(src, drawing);
+                this.view.images.set(src, drawing);
 
                 // Update progress on successful load
                 onProgress((++numLoaded) / imgSrcs.length);

--- a/src/app/core/public/api/impl/CircuitState.ts
+++ b/src/app/core/public/api/impl/CircuitState.ts
@@ -17,9 +17,7 @@ export type CircuitState<
 > = CircuitT & {
     circuit: CircuitInternal;
 
-    // TODO[model_refactor_api](leon): Get towards the point where this can always exist
-    //  even when there isn't a canvas/images loaded.
-    view?: CircuitView;
+    view: CircuitView;
 
     selectionsManager: SelectionsManager;
 

--- a/src/app/core/public/api/impl/Port.ts
+++ b/src/app/core/public/api/impl/Port.ts
@@ -38,11 +38,11 @@ export abstract class PortImpl<
 
     public get originPos(): Vector {
         // TODO[model_refactor_api]: This probably needs to be calculated explicitly here ?
-        return this.circuit.view!.portPositions.get(this.id)!.origin;
+        return this.circuit.view.getPortPos(this.id).unwrap().origin;
     }
     public get targetPos(): Vector {
         // TODO[model_refactor_api]: This probably needs to be calculated explicitly here ?
-        return this.circuit.view!.portPositions.get(this.id)!.target;
+        return this.circuit.view.getPortPos(this.id).unwrap().target;
     }
     public get dir(): Vector {
         return this.targetPos.sub(this.originPos).normalize();

--- a/src/app/core/public/api/impl/Port.ts
+++ b/src/app/core/public/api/impl/Port.ts
@@ -37,11 +37,9 @@ export abstract class PortImpl<
     }
 
     public get originPos(): Vector {
-        // TODO[model_refactor_api]: This probably needs to be calculated explicitly here ?
         return this.circuit.view.getPortPos(this.id).unwrap().origin;
     }
     public get targetPos(): Vector {
-        // TODO[model_refactor_api]: This probably needs to be calculated explicitly here ?
         return this.circuit.view.getPortPos(this.id).unwrap().target;
     }
     public get dir(): Vector {

--- a/src/app/digital/internal/views/DigitalCircuitView.ts
+++ b/src/app/digital/internal/views/DigitalCircuitView.ts
@@ -13,38 +13,35 @@ import {DigitalWireAssembler} from "./DigitalWireAssembler";
 
 export class DigitalCircuitView extends CircuitView {
     protected sim: DigitalSim;
-    protected assemblers?: Record<string, Assembler>;
+    protected assemblers: Record<string, Assembler>;
 
     public constructor(circuit: CircuitInternal, selections: SelectionsManager, sim: DigitalSim) {
         super(circuit, selections);
+
         this.sim = sim;
+        this.assemblers = {
+            // Base types
+            "DigitalWire": new DigitalWireAssembler(this.circuit, this, this.selections, this.sim),
+            "DigitalNode": new NodeAssembler(this.circuit, this, this.selections),
+
+            // Inputs
+            "Switch": new SwitchAssembler(this.circuit, this, this.selections, this.sim),
+
+            // Outputs
+            "LED": new LEDAssembler(this.circuit, this, this.selections, this.sim),
+
+            // Gates
+            "ANDGate": new ANDGateAssembler(this.circuit, this, this.selections, this.sim),
+
+            // FlipFlops
+
+            // Latches
+
+            // Other
+        };
     }
 
     protected getAssemblerFor(kind: string): Assembler<Obj> {
-        // Create assemblers on first call since some assemblers load images and so we need to defer it
-        if (!this.assemblers) {
-            this.assemblers = {
-                // Base types
-                "DigitalWire": new DigitalWireAssembler(this.circuit, this, this.selections, this.sim),
-                "DigitalNode": new NodeAssembler(this.circuit, this, this.selections),
-
-                // Inputs
-                "Switch": new SwitchAssembler(this.circuit, this, this.selections, this.sim),
-
-                // Outputs
-                "LED": new LEDAssembler(this.circuit, this, this.selections, this.sim),
-
-                // Gates
-                "ANDGate": new ANDGateAssembler(this.circuit, this, this.selections, this.sim),
-
-                // FlipFlops
-
-                // Latches
-
-                // Other
-            };
-        }
-
         // TODO[model_refactor](leon) - Consider going back to templating `kind`, but as a post-effort once the view
         //                               is all set-in-stone.
         if (!(kind in this.assemblers))

--- a/src/app/digital/internal/views/components/ANDGateAssembler.ts
+++ b/src/app/digital/internal/views/components/ANDGateAssembler.ts
@@ -17,9 +17,10 @@ import {Assembler}            from "core/internal/view/Assembler";
 
 export class ANDGateAssembler extends Assembler<Schema.Component> {
     public readonly size = V(1, 1);
-    public readonly img: SVGDrawing;
 
     protected readonly sim: DigitalSim;
+
+    public img?: SVGDrawing;
 
     protected portAssembler: PortAssembler;
 
@@ -28,7 +29,12 @@ export class ANDGateAssembler extends Assembler<Schema.Component> {
 
         this.sim = sim;
 
-        this.img = view.options.getImage("and.svg");
+        view.images.subscribe(({ key, val }) => {
+            if (key === "and.svg") {
+                this.img = val;
+                // TODO[model_refactor_api](leon) - Invalidate all AND gates to re-assemble with new image
+            }
+        });
 
         this.portAssembler = new PortAssembler(circuit, view, selections, {
             "outputs": () => ({ origin: V(0.5, 0), dir: V(1, 0) }),

--- a/src/app/digital/internal/views/components/LEDAssembler.ts
+++ b/src/app/digital/internal/views/components/LEDAssembler.ts
@@ -19,9 +19,10 @@ import {Signal}     from "digital/internal/sim/Signal";
 
 export class LEDAssembler extends Assembler<Schema.Component> {
     public readonly size = V(1, 1);
-    public readonly img: SVGDrawing;
 
     protected readonly sim: DigitalSim;
+
+    public img?: SVGDrawing;
 
     protected portAssembler: PortAssembler;
 
@@ -30,7 +31,12 @@ export class LEDAssembler extends Assembler<Schema.Component> {
 
         this.sim = sim;
 
-        this.img = view.options.getImage("led.svg");
+        view.images.subscribe(({ key, val }) => {
+            if (key === "led.svg") {
+                this.img = val;
+                // TODO[model_refactor_api](leon) - Invalidate all AND gates to re-assemble with new image
+            }
+        });
 
         this.portAssembler = new PortAssembler(circuit, view, selections, {
             "inputs": () => ({ origin: V(0, -0.5), target: V(0, -2) }),

--- a/src/app/digital/internal/views/components/SwitchAssembler.ts
+++ b/src/app/digital/internal/views/components/SwitchAssembler.ts
@@ -21,10 +21,10 @@ export class SwitchAssembler extends Assembler<Schema.Component> {
     public readonly size = V(1.24, 1.54);
     public readonly pressableSize = V(0.96, 1.2);
 
-    public readonly onImg: SVGDrawing;
-    public readonly offImg: SVGDrawing;
-
     protected readonly sim: DigitalSim;
+
+    public onImg?: SVGDrawing;
+    public offImg?: SVGDrawing;
 
     protected portAssembler: PortAssembler;
 
@@ -33,8 +33,15 @@ export class SwitchAssembler extends Assembler<Schema.Component> {
 
         this.sim = sim;
 
-        this.onImg  = view.options.getImage("switchDown.svg");
-        this.offImg = view.options.getImage("switchUp.svg");
+        view.images.subscribe(({ key, val }) => {
+            if (key === "switchDown.svg") {
+                this.onImg = val;
+                // TODO[model_refactor_api](leon) - Invalidate all AND gates to re-assemble with new image
+            } else if (key === "switchUp.svg") {
+                this.offImg = val;
+                // TODO[model_refactor_api](leon) - Invalidate all AND gates to re-assemble with new image
+            }
+        });
 
         this.portAssembler = new PortAssembler(circuit, view, selections, {
             "outputs": () => ({ origin: V(0.62, 0), dir: V(1, 0) }),

--- a/src/app/tests/FirstAvailable.test.ts
+++ b/src/app/tests/FirstAvailable.test.ts
@@ -4,12 +4,13 @@ import {CreateCircuit} from "digital/public";
 
 import "./Extensions";
 
+
 describe("FirstAvailable", () => {
     test("All ports available", () => {
         const circuit = CreateCircuit();
 
         const c = circuit.placeComponentAt(V(0, 0), "Multiplexer");
-        
+
         // Case: 'output' port group
         expect(c.firstAvailable("outputs")?.id).toEqual(c.ports["outputs"][0].id);
         // Case: 'input' port group
@@ -25,9 +26,9 @@ describe("FirstAvailable", () => {
         circuit.connectWire(s1.ports["outputs"][0], c1.ports["inputs"][0]);
 
         // There should be no available output ports for s1
-        expect(s1.firstAvailable('outputs')?.id).toEqual(undefined);
+        expect(s1.firstAvailable("outputs")?.id).toBeUndefined();
         // There should still be 1 input and output port available for c1
-        expect(c1.firstAvailable('inputs')?.id).toEqual(c1.ports["inputs"][1].id);
-        expect(c1.firstAvailable('outputs')?.id).toEqual(c1.ports["outputs"][0].id);
+        expect(c1.firstAvailable("inputs")?.id).toEqual(c1.ports["inputs"][1].id);
+        expect(c1.firstAvailable("outputs")?.id).toEqual(c1.ports["outputs"][0].id);
     });
 });

--- a/src/app/tests/FirstAvailable.test.ts
+++ b/src/app/tests/FirstAvailable.test.ts
@@ -25,8 +25,9 @@ describe("FirstAvailable", () => {
 
         circuit.connectWire(s1.ports["outputs"][0], c1.ports["inputs"][0]);
 
-        // There should be no available output ports for s1
-        expect(s1.firstAvailable("outputs")?.id).toBeUndefined();
+        // Switch should still have an available output port
+        expect(s1.firstAvailable("outputs")?.id).toEqual(s1.ports["outputs"][0].id);
+
         // There should still be 1 input and output port available for c1
         expect(c1.firstAvailable("inputs")?.id).toEqual(c1.ports["inputs"][1].id);
         expect(c1.firstAvailable("outputs")?.id).toEqual(c1.ports["outputs"][0].id);


### PR DESCRIPTION
Currently, the Circuit expects for a view, canvas, and images to exist. We want the Circuit to be able to exist in a "headless" state where the view can exists virtually and no rendering needs to be performed, but all assembled Prims can still be accessed for computed properties such as port positions.

This also allows images/assets to be lazy-loaded and fixes all of the units test failings. 