### PR TITLE
Add Circuit.find and findAll methods to replace other get methods

### DIFF
--- a/src/app/core/internal/view/CircuitView.ts
+++ b/src/app/core/internal/view/CircuitView.ts
@@ -67,6 +67,7 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
 
     public localPortPositions: Map<GUID, PortPos>; // Key'd by port ID
     public portPositions: Map<GUID, PortPos>; // Key'd by port ID
+    public iPortPrims: Map<GUID, Prims>; // Individual port prims, key'd by port ID
     public portPrims: Map<GUID, Prims>; // Key'd by component parent
 
     public wireCurves: Map<GUID, BezierCurve>;
@@ -96,6 +97,7 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
 
         this.localPortPositions = new Map();
         this.portPositions = new Map();
+        this.iPortPrims = new Map();
         this.portPrims = new Map();
 
         this.wireCurves = new Map();
@@ -237,6 +239,21 @@ export abstract class CircuitView extends Observable<{ renderer: RenderHelper }>
             this.dirtyComponents.delete(port.parent);
         }
         return Some(this.portPositions.get(portID)!);
+    }
+
+    private objContains(prims: Prims | undefined, pos: Vector): boolean {
+        if (!prims)
+            return false;
+        return prims.some((prim) => prim.hitTest(pos));
+    }
+    public componentContains(id: GUID, pos: Vector): boolean {
+        return this.objContains(this.componentPrims.get(id), pos);
+    }
+    public wireContains(id: GUID, pos: Vector): boolean {
+        return this.objContains(this.wirePrims.get(id), pos);
+    }
+    public portContains(id: GUID, pos: Vector): boolean {
+        return this.objContains(this.iPortPrims.get(id), pos);
     }
 
     public findNearestObj(pos: Vector, filter: (id: GUID) => boolean = ((_) => true)): Option<GUID> {

--- a/src/app/core/internal/view/PortAssembler.ts
+++ b/src/app/core/internal/view/PortAssembler.ts
@@ -105,10 +105,14 @@ export class PortAssembler extends Assembler<Schema.Component> {
 
                 // Assemble the port-line and port-circle
                 const { lineStyle, circleStyle } = this.options.portStyle(selected, parentSelected);
-                return [
+                const prims = [
                     new LinePrim(origin, target, lineStyle),
                     new CirclePrim(target, defaultPortRadius, circleStyle),
                 ];
+
+                this.view.iPortPrims.set(portID, prims);
+
+                return prims;
             });
 
             this.view.portPrims.set(parent.id, prims);

--- a/src/app/core/internal/view/rendering/prims/CirclePrim.ts
+++ b/src/app/core/internal/view/rendering/prims/CirclePrim.ts
@@ -1,7 +1,8 @@
 import {Vector} from "Vector";
 
-import {Style}         from "../Style";
-import {BaseShapePrim} from "./BaseShapePrim";
+import {Style}          from "../Style";
+import {BaseShapePrim}  from "./BaseShapePrim";
+import {CircleContains} from "math/MathUtils";
 
 
 /**
@@ -23,6 +24,10 @@ export class CirclePrim extends BaseShapePrim {
 
         this.pos = pos;
         this.radius = radius;
+    }
+
+    public override hitTest(pt: Vector): boolean {
+        return CircleContains(this.pos, this.radius, pt);
     }
 
     protected override renderShape(ctx: CanvasRenderingContext2D): void {

--- a/src/app/core/public/api/Circuit.ts
+++ b/src/app/core/public/api/Circuit.ts
@@ -68,18 +68,6 @@ export interface Circuit {
     // Queries
     find<K extends keyof Circuit.ObjQueryTypes>(kind: K): Circuit.ObjQuery<K>;
     findAll<K extends keyof Circuit.ObjQueryTypes>(kind: K): Circuit.MultiObjQuery<K>;
-    // pickObjAt(pt: Vector, space?: Vector.Spaces): Obj | undefined;
-    // pickComponentAt(pt: Vector, space?: Vector.Spaces): Component | undefined;
-    // pickWireAt(pt: Vector, space?: Vector.Spaces): Wire | undefined;
-    // pickPortAt(pt: Vector, space?: Vector.Spaces): Port | undefined;
-    // pickObjRange(bounds: Rect): Obj[];
-
-    // getComponent(id: GUID): Component | undefined;
-    // getWire(id: GUID): Wire | undefined;
-    // getPort(id: GUID): Port | undefined;
-    // getObj(id: GUID): Obj | undefined;
-    // getObjs(): Obj[];
-    // getComponents(): Component[];
     getComponentInfo(kind: string): ComponentInfo | undefined;
 
     // Object manipulation

--- a/src/app/core/public/api/Circuit.ts
+++ b/src/app/core/public/api/Circuit.ts
@@ -4,6 +4,8 @@ import {Rect} from "math/Rect";
 
 import {GUID} from "core/schema/GUID";
 
+import {CleanupFunc} from "core/utils/types"
+
 import {DebugOptions} from "core/internal/impl/DebugOptions";
 
 import {RenderHelper}  from "core/internal/view/rendering/RenderHelper";
@@ -16,8 +18,30 @@ import {Obj}           from "./Obj";
 import {Port}          from "./Port";
 import {Wire}          from "./Wire";
 import {Selections}    from "./Selections";
-import {CleanupFunc}   from "core/utils/types";
 
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Circuit {
+    export type ObjQueryTypes = {
+        "Component": Component;
+        "Wire": Wire;
+        "Port": Port;
+        "Component | Wire": Component | Wire;
+        "Component | Port": Component | Port;
+        "Wire | Port": Wire | Port;
+        "Obj": Obj;
+    }
+    export interface BaseObjQuery {
+        with(props: { id: GUID }): this;
+        at(pt: Vector, space?: Vector.Spaces): this;
+    }
+    export interface ObjQuery<K extends keyof ObjQueryTypes> extends BaseObjQuery {
+        readonly result: ObjQueryTypes[K] | undefined;
+    }
+    export interface MultiObjQuery<K extends keyof ObjQueryTypes> extends BaseObjQuery {
+        readonly result: Array<ObjQueryTypes[K]>;
+    }
+}
 
 export type {CircuitMetadata} from "core/schema/CircuitMetadata";
 
@@ -41,18 +65,20 @@ export interface Circuit {
     readonly selections: Selections;
 
     // Queries
-    pickObjAt(pt: Vector, space?: Vector.Spaces): Obj | undefined;
-    pickComponentAt(pt: Vector, space?: Vector.Spaces): Component | undefined;
-    pickWireAt(pt: Vector, space?: Vector.Spaces): Wire | undefined;
-    pickPortAt(pt: Vector, space?: Vector.Spaces): Port | undefined;
-    pickObjRange(bounds: Rect): Obj[];
+    find<K extends keyof Circuit.ObjQueryTypes>(kind: K): Circuit.ObjQuery<K>;
+    findAll<K extends keyof Circuit.ObjQueryTypes>(kind: K): Circuit.MultiObjQuery<K>;
+    // pickObjAt(pt: Vector, space?: Vector.Spaces): Obj | undefined;
+    // pickComponentAt(pt: Vector, space?: Vector.Spaces): Component | undefined;
+    // pickWireAt(pt: Vector, space?: Vector.Spaces): Wire | undefined;
+    // pickPortAt(pt: Vector, space?: Vector.Spaces): Port | undefined;
+    // pickObjRange(bounds: Rect): Obj[];
 
-    getComponent(id: GUID): Component | undefined;
-    getWire(id: GUID): Wire | undefined;
-    getPort(id: GUID): Port | undefined;
-    getObj(id: GUID): Obj | undefined;
-    getObjs(): Obj[];
-    getComponents(): Component[];
+    // getComponent(id: GUID): Component | undefined;
+    // getWire(id: GUID): Wire | undefined;
+    // getPort(id: GUID): Port | undefined;
+    // getObj(id: GUID): Obj | undefined;
+    // getObjs(): Obj[];
+    // getComponents(): Component[];
     getComponentInfo(kind: string): ComponentInfo | undefined;
 
     // Object manipulation

--- a/src/app/core/public/api/Circuit.ts
+++ b/src/app/core/public/api/Circuit.ts
@@ -34,6 +34,7 @@ export namespace Circuit {
     export interface BaseObjQuery {
         with(props: { id: GUID }): this;
         at(pt: Vector, space?: Vector.Spaces): this;
+        within(bounds: Rect, space?: Vector.Spaces): this;
     }
     export interface ObjQuery<K extends keyof ObjQueryTypes> extends BaseObjQuery {
         readonly result: ObjQueryTypes[K] | undefined;

--- a/src/app/core/public/api/impl/Circuit.ts
+++ b/src/app/core/public/api/impl/Circuit.ts
@@ -152,58 +152,6 @@ export function CircuitImpl<CircuitT extends Circuit, T extends CircuitTypes>(st
             return SelectionsImpl(state);
         },
 
-        // Queries
-        // pickObjAt(pt: Vector, space: Vector.Spaces = "world"): T["Obj"] | undefined {
-        //     return pickObjAtHelper(pt, space)
-        //         .map((id) => this.getObj(id)).asUnion();
-        // },
-        // pickComponentAt(pt: Vector, space: Vector.Spaces = "world"): T["Component"] | undefined {
-        //     return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasComp(id))
-        //         .map((id) => this.getComponent(id)).asUnion();
-        // },
-        // pickWireAt(pt: Vector, space: Vector.Spaces = "world"): T["Wire"] | undefined {
-        //     return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasWire(id))
-        //         .map((id) => this.getWire(id)).asUnion();
-        // },
-        // pickPortAt(pt: Vector, space: Vector.Spaces = "world"): T["Port"] | undefined {
-        //     return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasPort(id))
-        //         .map((id) => this.getPort(id)).asUnion();
-        // },
-        // pickObjRange(bounds: Rect): T["Obj[]"] {
-        //     throw new Error("Unimplemented!");
-        // },
-
-        // getComponent(id: GUID): T["Component"] | undefined {
-        //     if (!state.internal.doc.getCompByID(id))
-        //         return undefined;
-        //     return state.constructComponent(id);
-        // },
-        // getWire(id: GUID): T["Wire"] | undefined {
-        //     if (!state.internal.doc.getWireByID(id))
-        //         return undefined;
-        //     return state.constructWire(id);
-        // },
-        // getPort(id: GUID): T["Port"] | undefined {
-        //     if (!state.internal.doc.getPortByID(id))
-        //         return undefined;
-        //     return state.constructPort(id);
-        // },
-        // getObj(id: GUID): T["Obj"] | undefined {
-        //     if (state.internal.doc.hasComp(id))
-        //         return this.getComponent(id);
-        //     if (state.internal.doc.hasWire(id))
-        //         return this.getWire(id);
-        //     if (state.internal.doc.hasPort(id))
-        //         return this.getPort(id);
-        //     return undefined;
-        // },
-        // getObjs(): T["Obj[]"] {
-        //     return [...state.internal.doc.getObjs()]
-        //         .map((id) => this.getObj(id)!);
-        // },
-        // getComponents(): T["Component[]"] {
-        //     return this.getObjs().filter(isObjComponent);
-        // },
         getComponentInfo(kind: string): T["ComponentInfo"] | undefined {
             // TODO[.](kevin) - getComponentInfo should probably return a Result right?
             //                  Or should we add a method to check if a component exists?

--- a/src/app/core/public/api/impl/Circuit.ts
+++ b/src/app/core/public/api/impl/Circuit.ts
@@ -88,57 +88,63 @@ export function CircuitImpl<CircuitT extends Circuit, T extends CircuitTypes>(st
         },
 
         // Queries
-        pickObjAt(pt: Vector, space: Vector.Spaces = "world"): T["Obj"] | undefined {
-            return pickObjAtHelper(pt, space)
-                .map((id) => this.getObj(id)).asUnion();
-        },
-        pickComponentAt(pt: Vector, space: Vector.Spaces = "world"): T["Component"] | undefined {
-            return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasComp(id))
-                .map((id) => this.getComponent(id)).asUnion();
-        },
-        pickWireAt(pt: Vector, space: Vector.Spaces = "world"): T["Wire"] | undefined {
-            return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasWire(id))
-                .map((id) => this.getWire(id)).asUnion();
-        },
-        pickPortAt(pt: Vector, space: Vector.Spaces = "world"): T["Port"] | undefined {
-            return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasPort(id))
-                .map((id) => this.getPort(id)).asUnion();
-        },
-        pickObjRange(bounds: Rect): T["Obj[]"] {
+        find(kind) {
             throw new Error("Unimplemented!");
         },
+        findAll(kind) {
+            throw new Error("Unimplemented!");
+        },
+        // pickObjAt(pt: Vector, space: Vector.Spaces = "world"): T["Obj"] | undefined {
+        //     return pickObjAtHelper(pt, space)
+        //         .map((id) => this.getObj(id)).asUnion();
+        // },
+        // pickComponentAt(pt: Vector, space: Vector.Spaces = "world"): T["Component"] | undefined {
+        //     return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasComp(id))
+        //         .map((id) => this.getComponent(id)).asUnion();
+        // },
+        // pickWireAt(pt: Vector, space: Vector.Spaces = "world"): T["Wire"] | undefined {
+        //     return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasWire(id))
+        //         .map((id) => this.getWire(id)).asUnion();
+        // },
+        // pickPortAt(pt: Vector, space: Vector.Spaces = "world"): T["Port"] | undefined {
+        //     return pickObjAtHelper(pt, space, (id) => state.internal.doc.hasPort(id))
+        //         .map((id) => this.getPort(id)).asUnion();
+        // },
+        // pickObjRange(bounds: Rect): T["Obj[]"] {
+        //     throw new Error("Unimplemented!");
+        // },
 
-        getComponent(id: GUID): T["Component"] | undefined {
-            if (!state.internal.doc.getCompByID(id))
-                return undefined;
-            return state.constructComponent(id);
-        },
-        getWire(id: GUID): T["Wire"] | undefined {
-            if (!state.internal.doc.getWireByID(id))
-                return undefined;
-            return state.constructWire(id);
-        },
-        getPort(id: GUID): T["Port"] | undefined {
-            if (!state.internal.doc.getPortByID(id))
-                return undefined;
-            return state.constructPort(id);
-        },
-        getObj(id: GUID): T["Obj"] | undefined {
-            if (state.internal.doc.hasComp(id))
-                return this.getComponent(id);
-            if (state.internal.doc.hasWire(id))
-                return this.getWire(id);
-            if (state.internal.doc.hasPort(id))
-                return this.getPort(id);
-            return undefined;
-        },
-        getObjs(): T["Obj[]"] {
-            return [...state.internal.doc.getObjs()]
-                .map((id) => this.getObj(id)!);
-        },
-        getComponents(): T["Component[]"] {
-            return this.getObjs().filter(isObjComponent);
-        },
+        // getComponent(id: GUID): T["Component"] | undefined {
+        //     if (!state.internal.doc.getCompByID(id))
+        //         return undefined;
+        //     return state.constructComponent(id);
+        // },
+        // getWire(id: GUID): T["Wire"] | undefined {
+        //     if (!state.internal.doc.getWireByID(id))
+        //         return undefined;
+        //     return state.constructWire(id);
+        // },
+        // getPort(id: GUID): T["Port"] | undefined {
+        //     if (!state.internal.doc.getPortByID(id))
+        //         return undefined;
+        //     return state.constructPort(id);
+        // },
+        // getObj(id: GUID): T["Obj"] | undefined {
+        //     if (state.internal.doc.hasComp(id))
+        //         return this.getComponent(id);
+        //     if (state.internal.doc.hasWire(id))
+        //         return this.getWire(id);
+        //     if (state.internal.doc.hasPort(id))
+        //         return this.getPort(id);
+        //     return undefined;
+        // },
+        // getObjs(): T["Obj[]"] {
+        //     return [...state.internal.doc.getObjs()]
+        //         .map((id) => this.getObj(id)!);
+        // },
+        // getComponents(): T["Component[]"] {
+        //     return this.getObjs().filter(isObjComponent);
+        // },
         getComponentInfo(kind: string): T["ComponentInfo"] | undefined {
             // TODO[.](kevin) - getComponentInfo should probably return a Result right?
             //                  Or should we add a method to check if a component exists?

--- a/src/app/core/public/api/impl/CircuitState.ts
+++ b/src/app/core/public/api/impl/CircuitState.ts
@@ -40,4 +40,5 @@ export interface CircuitState<T extends CircuitTypes> {
     constructComponent(id: string): T["Component"];
     constructWire(id: string): T["Wire"];
     constructPort(id: string): T["Port"];
+    constructObj(id: string): T["Obj"];
 }

--- a/src/app/core/public/api/impl/Component.ts
+++ b/src/app/core/public/api/impl/Component.ts
@@ -8,7 +8,6 @@ import {Schema} from "core/schema";
 
 import {Circuit}   from "../Circuit";
 import {Component} from "../Component";
-import {Port}      from "../Port";
 
 import {BaseObjectImpl}             from "./BaseObject";
 import {CircuitState, CircuitTypes} from "./CircuitState";
@@ -78,7 +77,7 @@ export function ComponentImpl<T extends CircuitTypes>(
             const curConfig = {} as Record<string, number>;
             internal.doc.getPortsForComponent(base.id)
                 .map((ids) => [...ids]
-                    .map((id) => circuit.getPort(id)!))
+                    .map((id) => internal.doc.getPortByID(id).unwrap()))
                 .unwrap()
                 .forEach(({ group }) =>
                     curConfig[group] = (curConfig[group] ?? 0) + 1);

--- a/src/app/core/public/api/impl/Selections.ts
+++ b/src/app/core/public/api/impl/Selections.ts
@@ -1,13 +1,11 @@
 import {V, Vector} from "Vector";
 
 import {Selections} from "../Selections";
-import {Circuit}    from "../Circuit";
 
 import {CircuitState, CircuitTypes} from "./CircuitState";
 
 
 export function SelectionsImpl<T extends CircuitTypes>(
-    circuit: Circuit,
     { internal, selectionsManager, view, constructComponent, constructWire, constructObj }: CircuitState<T>
 ) {
     function selections() {

--- a/src/app/core/public/api/impl/Selections.ts
+++ b/src/app/core/public/api/impl/Selections.ts
@@ -8,7 +8,7 @@ import {CircuitState, CircuitTypes} from "./CircuitState";
 
 export function SelectionsImpl<T extends CircuitTypes>(
     circuit: Circuit,
-    { internal, selectionsManager, view, constructComponent, constructWire }: CircuitState<T>
+    { internal, selectionsManager, view, constructComponent, constructWire, constructObj }: CircuitState<T>
 ) {
     function selections() {
         return selectionsManager.get();
@@ -23,7 +23,7 @@ export function SelectionsImpl<T extends CircuitTypes>(
         },
 
         get all(): T["Obj[]"] {
-            return selections().map((id) => circuit.getObj(id)!);
+            return selections().map((id) => constructObj(id));
         },
         get components(): T["Component[]"] {
             return selections().filter((id) => (internal.doc.hasComp(id)))

--- a/src/app/digital/public/api/DigitalCircuit.ts
+++ b/src/app/digital/public/api/DigitalCircuit.ts
@@ -9,6 +9,13 @@ import type {DigitalWire}                   from "./DigitalWire";
 import type {DigitalPort}                   from "./DigitalPort";
 
 
+export interface DigitalObjQuery<K extends keyof Circuit.ObjQueryTypes> extends Circuit.BaseObjQuery {
+    readonly result: ToDigital<Circuit.ObjQueryTypes>[K] | undefined;
+}
+export interface DigitalMultiObjQuery<K extends keyof Circuit.ObjQueryTypes> extends Circuit.BaseObjQuery {
+    readonly result: Array<ToDigital<Circuit.ObjQueryTypes>[K]>;
+}
+
 export type ToDigital<T> = (
     // Core types to keep the same and return early on (and prevent infinite recursion)
     T extends Vector ? Vector :
@@ -36,5 +43,8 @@ export type APIToDigital<T> = {
 
 
 export interface DigitalCircuit extends APIToDigital<Circuit> {
+    find<K extends keyof Circuit.ObjQueryTypes>(type: K): DigitalObjQuery<K>;
+    findAll<K extends keyof Circuit.ObjQueryTypes>(type: K): DigitalMultiObjQuery<K>;
+
     propagationTime: number;
 }

--- a/src/app/digital/public/api/impl/DigitalCircuit.ts
+++ b/src/app/digital/public/api/impl/DigitalCircuit.ts
@@ -1,15 +1,32 @@
-import {CircuitImpl} from "core/public/api/impl/Circuit";
+import type {Circuit} from "core/public/api/Circuit";
+
+import {CircuitImpl, MultiObjQueryImpl, ObjQueryImpl} from "core/public/api/impl/Circuit";
 
 import {extend} from "core/utils/Functions";
 
-import {DigitalCircuit}                    from "../DigitalCircuit";
-import {DigitalCircuitState, DigitalTypes} from "./DigitalCircuitState";
+import {DigitalCircuit, DigitalMultiObjQuery, DigitalObjQuery, ToDigital} from "../DigitalCircuit";
+import {DigitalCircuitState, DigitalTypes}                                from "./DigitalCircuitState";
 
 
 export function DigitalCircuitImpl(state: DigitalCircuitState) {
     const base = CircuitImpl<DigitalCircuit, DigitalTypes>(state);
 
+
+    function getObjsByKind<K extends keyof Circuit.ObjQueryTypes>(kind: K): Array<Circuit.ObjQueryTypes[K]> {
+        const objs = [...state.internal.doc.getObjs()].map(state.constructObj);
+        if (kind === "Obj")
+            return objs as Array<ToDigital<Circuit.ObjQueryTypes>[K]>;
+        return objs.filter((obj): obj is ToDigital<Circuit.ObjQueryTypes>[K] => (kind.includes(obj.baseKind)));
+    }
+
     return extend(base, {
+        find<K extends keyof Circuit.ObjQueryTypes>(type: K): DigitalObjQuery<K> {
+            return ObjQueryImpl(state, getObjsByKind(type)) as DigitalObjQuery<K>;
+        },
+        findAll<K extends keyof Circuit.ObjQueryTypes>(type: K): DigitalMultiObjQuery<K> {
+            return MultiObjQueryImpl(state, getObjsByKind(type)) as DigitalMultiObjQuery<K>;
+        },
+
         set propagationTime(val: number) {
             throw new Error("Unimplemented!");
         },

--- a/src/app/digital/public/index.ts
+++ b/src/app/digital/public/index.ts
@@ -40,6 +40,15 @@ export function CreateCircuit(): DigitalCircuit {
         constructPort(id) {
             return DigitalPortImpl(circuit, state, id);
         },
+        constructObj(id) {
+            if (internal.doc.hasComp(id))
+                return DigitalComponentImpl(circuit, state, id);
+            else if (internal.doc.hasWire(id))
+                return DigitalWireImpl(circuit, state, id);
+            else if (internal.doc.hasPort(id))
+                return DigitalPortImpl(circuit, state, id);
+            throw new Error(`Cannot construct object with id ${id}!`);
+        },
     }
     const circuit = DigitalCircuitImpl(state);
 

--- a/src/site/shared/tools/DefaultTool.ts
+++ b/src/site/shared/tools/DefaultTool.ts
@@ -22,7 +22,7 @@ export class DefaultTool {
 
         if (ev.type === "mousedown") {
             // Find object if we pressed on one
-            designer.curPressedObj = designer.circuit.pickObjAt(ev.input.mousePos, "screen");
+            designer.curPressedObj = designer.circuit.find("Obj").at(ev.input.mousePos, "screen").result;
         } else if (ev.type === "mouseup") {
             designer.curPressedObj = undefined;
         }

--- a/src/site/shared/tools/SelectionBoxTool.ts
+++ b/src/site/shared/tools/SelectionBoxTool.ts
@@ -36,7 +36,7 @@ export class SelectionBoxTool implements Tool {
 
     public onDeactivate(ev: InputAdapterEvent, { circuit }: CircuitDesigner): void {
         // Find all objects within the selection box
-        const objs = circuit.pickObjRange(this.rect);
+        const { result: objs } = circuit.findAll("Obj").within(this.rect);
 
         const deselectAll = (!ev.input.isShiftKeyDown && circuit.selections.length > 0);
 

--- a/src/site/shared/tools/WiringTool.ts
+++ b/src/site/shared/tools/WiringTool.ts
@@ -38,14 +38,13 @@ export class WiringTool implements Tool {
         const worldPos = circuit.camera.toWorldPos(pos);
 
         // First see if there is a port that we are directly within the bounds of
-        const p1 = circuit.pickPortAt(worldPos);
+        const { result: p1 } = circuit.find("Port").at(worldPos);
         if (p1)
             return p1;
 
         // Otherwise, gather all ports that are within the wireable
         //  bounds (and can be wired), and find the closest one
-        const allPorts = circuit.getObjs()
-            .filter((obj) => (obj.baseKind === "Port")) as Port[];
+        const { result: allPorts } = circuit.findAll("Port");
         const validPorts = allPorts
             // Make sure port is wireable
             .filter((port) => !port.getLegalWires().isEmpty)

--- a/src/site/shared/tools/handlers/CleanupHandler.ts
+++ b/src/site/shared/tools/handlers/CleanupHandler.ts
@@ -11,7 +11,7 @@ export const CleanupHandler: ToolHandler = {
 
         // Get selected components if we have selections, or get all components to cleanup
         const comps = (circuit.selections.isEmpty
-            ? circuit.getComponents()
+            ? circuit.findAll("Component").result
             : circuit.selections.components);
 
         if (comps.length === 0)

--- a/src/site/shared/tools/handlers/FitToScreenHandler.ts
+++ b/src/site/shared/tools/handlers/FitToScreenHandler.ts
@@ -12,7 +12,7 @@ export const FitToScreenHandler: ToolHandler = {
         circuit.camera.zoomToFit(
             // Fit selections if there are any, otherwise fit entire circuit
             (circuit.selections.isEmpty
-                ? circuit.getObjs()
+                ? circuit.findAll("Obj").result
                 : circuit.selections.all),
             FIT_PADDING_RATIO
         );

--- a/src/site/shared/tools/handlers/SelectAllHandler.ts
+++ b/src/site/shared/tools/handlers/SelectAllHandler.ts
@@ -7,7 +7,7 @@ export const SelectAllHandler: ToolHandler = {
         if (!(ev.type === "keydown" && ev.key === "a" && ev.input.isModifierKeyDown))
             return ToolHandlerResponse.PASS;
 
-        const comps = circuit.getComponents();
+        const { result: comps } = circuit.findAll("Component");
         // Don't select all if nothing to select or everything is already selected
         // TODO[.](kevin) - is this necessary anymore? it was here to prevent unnecessary entries in the
         //                  action history, but will this be automatically detected now?

--- a/src/site/shared/tools/handlers/SelectPathHandler.ts
+++ b/src/site/shared/tools/handlers/SelectPathHandler.ts
@@ -9,7 +9,7 @@ export const SelectPathHandler: ToolHandler = {
             return ToolHandlerResponse.PASS;
 
         // Make sure we double clicked on something
-        const obj = circuit.pickObjAt(ev.input.worldMousePos);
+        const { result: obj } = circuit.find("Obj").at(ev.input.worldMousePos);
         if (!obj)
             return ToolHandlerResponse.PASS;
 

--- a/src/site/shared/tools/handlers/SelectionHandler.ts
+++ b/src/site/shared/tools/handlers/SelectionHandler.ts
@@ -9,7 +9,7 @@ export const SelectionHandler: ToolHandler = {
 
         const deselectAll = (!ev.input.isShiftKeyDown && circuit.selections.length > 0);
 
-        const obj = circuit.pickObjAt(ev.input.mousePos, "screen");
+        const { result: obj } = circuit.find("Obj").at(ev.input.mousePos, "screen");
         if (!obj) {
             // Clear selections if not holding shift
             if (deselectAll) {


### PR DESCRIPTION
I'm very much still unsure if this change is worth making, my solution feels hacky but unfortunately it's the only way I found to make it work.

The problem resides in that apparently templated methods like the `find` method cannot be acted on by something like `ToDigital` as it will strip it of it's templating. I think this is related to something called ["higher kinded types"](https://github.com/Microsoft/TypeScript/issues/1213), which is just a fundamental TS limitation.

That means each sub-project of the API will have to declare the find/findAll methods explicitly with their types which might not be that big of a deal and we can further make some core utility for typing it explicitly but it's not ... great

If these end up being the only instances of templated methods then it might just simply not be worth the effort but idk.

Not sure it even really cleans up the usage much (at least currently), but theoretically it could allow for some nice fancy querying when the queries are more complex than "get all components".

Thoughts?