### PR TITLE
Add IC name rendering

### DIFF
--- a/src/projects/digital/api/circuit/src/internal/assembly/components/LabelAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/LabelAssembler.ts
@@ -89,9 +89,7 @@ export class LabelAssembler extends ComponentAssembler {
     private getFontStyle(comp: Schema.Component): FontStyle {
         return {
             ...this.options.fontStyle(),
-            font:  this.options.defaultFont,
             color: this.getTextColor(comp),
-            scale: 1000,
         }
     }
 }

--- a/src/projects/digital/site/src/containers/ICDesigner/index.tsx
+++ b/src/projects/digital/site/src/containers/ICDesigner/index.tsx
@@ -130,6 +130,7 @@ export const ICDesigner = ({ }: Props) => {
         if (!icViewDesigner)
             return;
         icViewDesigner.circuit.getICs()[0].name = name;
+        // TODO: Increase IC size if name gets too long for current size
     }
 
 
@@ -159,6 +160,9 @@ export const ICDesigner = ({ }: Props) => {
 
         // Unblock main input
         mainDesigner.viewport.canvasInfo!.input.setBlocked(false);
+
+        // Reset IC name input in designer back to empty
+        setICName(undefined);
 
         dispatch(CloseICDesigner());
     }

--- a/src/projects/digital/site/src/utils/CircuitUtils.ts
+++ b/src/projects/digital/site/src/utils/CircuitUtils.ts
@@ -12,7 +12,7 @@ export function CalculateICDisplay(circuit: Circuit): ReadonlyIntegratedCircuitD
     ) + circuit.name.length;
 
     const w = 1 + 0.3*longestName;
-    const h = inputs.length/2;
+    const h = Math.max(inputs.length, outputs.length)/2;
 
     const inputYs  = linspace(1, -1, inputs.length,  { endpoint: false, centered: true });
     const outputYs = linspace(1, -1, outputs.length, { endpoint: false, centered: true });

--- a/src/projects/shared/api/circuit/src/internal/assembly/ICComponentAssembler.ts
+++ b/src/projects/shared/api/circuit/src/internal/assembly/ICComponentAssembler.ts
@@ -4,6 +4,7 @@ import {ComponentAssembler} from "./ComponentAssembler";
 import {Schema} from "../../schema";
 import {GUID} from "../../public";
 import {MapObj} from "../../utils/Functions";
+import {Rect} from "math/Rect";
 
 
 export class ICComponentAssembler extends ComponentAssembler {
@@ -43,8 +44,28 @@ export class ICComponentAssembler extends ComponentAssembler {
 
                 styleChangesWhenSelected: true,
                 getStyle: (comp) => this.options.fillStyle(this.isSelected(comp.id)),
+            },
+            {
+                kind: "Text",
+
+                dependencies: new Set([AssemblyReason.TransformChanged]),
+                assemble:     (comp) => this.assembleText(comp),
+
+                getFontStyle: () => this.options.fontStyle(),
             }]
         );
+    }
+
+    private assembleText(comp: Schema.Component) {
+        const name = this.circuit.getICInfo(comp.kind).unwrap().metadata.name;
+        const bounds = this.options.textMeasurer?.getBounds(this.options.fontStyle(), name) ?? new Rect(V(), V());
+        return {
+            kind:     "Text",
+            pos:      this.getPos(comp),
+            contents: name,
+            angle:    this.getAngle(comp),
+            offset:   bounds.center,
+        } as const
     }
 
     protected override getSize(comp: Schema.Component): Vector {

--- a/src/projects/shared/site/src/containers/SelectionPopup/modules/inputs/TextModuleInputField.tsx
+++ b/src/projects/shared/site/src/containers/SelectionPopup/modules/inputs/TextModuleInputField.tsx
@@ -22,7 +22,7 @@ export const TextModuleInputField = ({
             ref={ref}
             type="text"
             value={state.values}
-            placeholder={state.allSame[0] ? "" : (placeholder ?? "-")}
+            placeholder={(state.allSame[0] && state.values.length > 1) ? "" : (placeholder ?? "-")}
             alt={alt}
             onChange={(ev) => setState.onChange(ev.target.value)}
             onFocus={() => setState.onFocus()}


### PR DESCRIPTION
This pr also:
- Removes a coupe redundant props in Label's getFontStyle (they were just the defaults from this.options.fontStyle())
- Reset IC name input back to empty after closing IC designer
- Base default IC height off of the max between the number of inputs and outputs, not solely the number of inputs
- Make the IC name placeholder actually show up

Still open IC designer issues:
- [ ] Increase IC size with IC name size (tried it, couldn't figure out how to get port names to recalculate with)