### PR TITLE
Mild Schema changes

### DIFF
--- a/src/projects/digital/api/circuit/src/internal/assembly/DigitalWireAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/DigitalWireAssembler.ts
@@ -4,8 +4,8 @@ import {AssemblerParams, AssemblyReason} from "shared/api/circuit/internal/assem
 import {Style}           from "shared/api/circuit/internal/assembly/Style";
 import {WireAssembler}   from "shared/api/circuit/internal/assembly/WireAssembler";
 
-import {DigitalSim} from "../sim/DigitalSim";
-import {Signal}     from "../sim/Signal";
+import {Signal}     from "digital/api/circuit/schema/Signal";
+import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 
 
 export class DigitalWireAssembler extends WireAssembler {

--- a/src/projects/digital/api/circuit/src/internal/assembly/components/ButtonAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/ButtonAssembler.ts
@@ -2,7 +2,7 @@ import {V, Vector} from "Vector";
 
 import {Schema} from "shared/api/circuit/schema";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 import {AssemblerParams, AssemblyReason} from "shared/api/circuit/internal/assembly/Assembler";
 import {DigitalComponentConfigurationInfo} from "../../DigitalComponents";

--- a/src/projects/digital/api/circuit/src/internal/assembly/components/ClockAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/ClockAssembler.ts
@@ -2,7 +2,7 @@ import {V, Vector} from "Vector";
 
 import {Schema} from "shared/api/circuit/schema";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 import {AssemblerParams, AssemblyReason} from "shared/api/circuit/internal/assembly/Assembler";
 import {DigitalComponentConfigurationInfo} from "../../DigitalComponents";

--- a/src/projects/digital/api/circuit/src/internal/assembly/components/LEDAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/LEDAssembler.ts
@@ -8,7 +8,7 @@ import {AssemblerParams, AssemblyReason} from "shared/api/circuit/internal/assem
 import {ComponentAssembler}              from "shared/api/circuit/internal/assembly/ComponentAssembler";
 import {Style}                           from "shared/api/circuit/internal/assembly/Style";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 
 import {DigitalComponentConfigurationInfo} from "../../DigitalComponents";

--- a/src/projects/digital/api/circuit/src/internal/assembly/components/OscilloscopeAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/OscilloscopeAssembler.ts
@@ -4,7 +4,7 @@ import {Schema} from "shared/api/circuit/schema";
 
 import {AssemblerParams, AssemblyReason} from "shared/api/circuit/internal/assembly/Assembler";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 
 import {DigitalComponentConfigurationInfo} from "../../DigitalComponents";

--- a/src/projects/digital/api/circuit/src/internal/assembly/components/SwitchAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/SwitchAssembler.ts
@@ -2,7 +2,7 @@ import {V, Vector} from "Vector";
 
 import {Schema} from "shared/api/circuit/schema";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 import {AssemblerParams, AssemblyReason} from "shared/api/circuit/internal/assembly/Assembler";
 import {DigitalComponentConfigurationInfo} from "../../DigitalComponents";

--- a/src/projects/digital/api/circuit/src/internal/assembly/components/displays/BaseDisplayAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/displays/BaseDisplayAssembler.ts
@@ -5,7 +5,7 @@ import {AssemblerParams, AssemblyReason} from "shared/api/circuit/internal/assem
 
 import {DigitalComponentConfigurationInfo} from "digital/api/circuit/internal/DigitalComponents";
 import {DigitalSim}           from "digital/api/circuit/internal/sim/DigitalSim";
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {Transform} from "math/Transform";
 import {Schema} from "shared/api/circuit/schema";
 import {Style} from "shared/api/circuit/internal/assembly/Style";

--- a/src/projects/digital/api/circuit/src/internal/sim/DigitalPropagators.ts
+++ b/src/projects/digital/api/circuit/src/internal/sim/DigitalPropagators.ts
@@ -1,6 +1,8 @@
 import {Schema} from "shared/api/circuit/schema";
-import {Signal} from "./Signal";
-import {BCDtoDecimal, DecimalToBCD} from "../../utils/MathUtil";
+
+import {BCDtoDecimal, DecimalToBCD} from "digital/api/circuit/utils/MathUtil";
+import {Signal}                     from "digital/api/circuit/schema/Signal";
+
 import {PropagatorInfo, PropagatorsMap} from "./DigitalSim";
 
 

--- a/src/projects/digital/api/circuit/src/internal/sim/DigitalSim.ts
+++ b/src/projects/digital/api/circuit/src/internal/sim/DigitalSim.ts
@@ -1,13 +1,15 @@
-import {CircuitInternal, GUID} from "shared/api/circuit/internal";
-import {ObservableImpl}        from "shared/api/circuit/utils/Observable";
-import {Signal}                from "./Signal";
-import {DigitalComponentConfigurationInfo} from "../DigitalComponents";
-import {AddErrE} from "shared/api/circuit/utils/MultiError";
+import {ObservableImpl}         from "shared/api/circuit/utils/Observable";
+import {AddErrE}                from "shared/api/circuit/utils/MultiError";
+import {MapObj}                 from "shared/api/circuit/utils/Functions";
+import {CircuitInternal, GUID}  from "shared/api/circuit/internal";
 import {ReadonlyCircuitStorage} from "shared/api/circuit/internal/impl/CircuitDocument";
-import {MapObj} from "shared/api/circuit/utils/Functions";
-import {Schema} from "shared/api/circuit/schema";
+import {Schema}                 from "shared/api/circuit/schema";
+import {ObjContainer}           from "shared/api/circuit/public/ObjContainer";
+
 import {DigitalSchema} from "digital/api/circuit/schema";
-import {ObjContainer} from "shared/api/circuit/public/ObjContainer";
+import {Signal}        from "digital/api/circuit/schema/Signal";
+
+import {DigitalComponentConfigurationInfo} from "../DigitalComponents";
 
 
 export interface PropagatorInfo {
@@ -16,9 +18,6 @@ export interface PropagatorInfo {
     // that the output state of the component is dependent on
     // (i.e. `inputNum` for ConstantNumber)
     stateProps?: Set<string>;
-}
-export interface TickInfo {
-
 }
 export type PropagatorFunc = (
     comp: Schema.Component,

--- a/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
@@ -14,6 +14,7 @@ import type {
     ReadonlyNode,
     ReadonlyPort,
     ReadonlyWire,
+    Selections,
     Wire,
 } from "shared/api/circuit/public";
 import type {Schema} from "shared/api/circuit/schema";
@@ -23,6 +24,7 @@ import type {DigitalComponent, DigitalNode, ReadonlyDigitalComponent, ReadonlyDi
 import type {DigitalWire, ReadonlyDigitalWire}                   from "./DigitalWire";
 import type {DigitalPort, ReadonlyDigitalPort}                   from "./DigitalPort";
 import type {DigitalSchema} from "digital/api/circuit/schema";
+import {ObjContainer} from "shared/api/circuit/public/ObjContainer";
 
 
 export type ToDigital<T> = (
@@ -31,7 +33,6 @@ export type ToDigital<T> = (
     T extends Rect   ? Rect   :
     // Schema-type
     T extends Schema.Circuit ? DigitalSchema.DigitalCircuit :
-    T extends Schema.IntegratedCircuit ? DigitalSchema.DigitalIntegratedCircuit :
     // Base-type replacements
     T extends IntegratedCircuit ? DigitalIntegratedCircuit :
     T extends Circuit           ? DigitalCircuit :
@@ -41,6 +42,8 @@ export type ToDigital<T> = (
     T extends Port              ? DigitalPort :
     T extends ComponentInfo     ? DigitalComponentInfo :
     T extends ICInfo            ? DigitalICInfo :
+    T extends Selections        ? APIToDigital<Selections> :
+    T extends ObjContainer      ? DigitalObjContainer :
     // Base-Readonly-type replacements
     T extends ReadonlyCircuit   ? ReadonlyDigitalCircuit :
     T extends ReadonlyNode      ? ReadonlyDigitalNode :
@@ -61,6 +64,7 @@ export type APIToDigital<T> = {
     [key in keyof T]: ToDigital<T[key]>;
 }
 
+export type DigitalObjContainer = APIToDigital<ObjContainer>;
 
 export type ReadonlyDigitalCircuit = APIToDigital<ReadonlyCircuit>;
 export type DigitalCircuit = APIToDigital<Circuit> & ReadonlyDigitalCircuit & {
@@ -69,5 +73,7 @@ export type DigitalCircuit = APIToDigital<Circuit> & ReadonlyDigitalCircuit & {
     step(): void;
 };
 
-export type DigitalIntegratedCircuit = APIToDigital<IntegratedCircuit>;
+export type DigitalIntegratedCircuit = APIToDigital<IntegratedCircuit> & {
+    readonly initialSimState: DigitalSchema.DigitalSimState;
+}
 export type DigitalICInfo = APIToDigital<ICInfo>;

--- a/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
@@ -16,12 +16,13 @@ import type {
     ReadonlyWire,
     Wire,
 } from "shared/api/circuit/public";
+import type {Schema} from "shared/api/circuit/schema";
 
 import type {DigitalComponentInfo}          from "./DigitalComponentInfo";
 import type {DigitalComponent, DigitalNode, ReadonlyDigitalComponent, ReadonlyDigitalNode} from "./DigitalComponent";
 import type {DigitalWire, ReadonlyDigitalWire}                   from "./DigitalWire";
 import type {DigitalPort, ReadonlyDigitalPort}                   from "./DigitalPort";
-import {Schema} from "../schema";
+import type {DigitalSchema} from "digital/api/circuit/schema";
 
 
 export type ToDigital<T> = (
@@ -29,8 +30,8 @@ export type ToDigital<T> = (
     T extends Vector ? Vector :
     T extends Rect   ? Rect   :
     // Schema-type
-    T extends Schema.Core.Circuit ? Schema.DigitalCircuit :
-    T extends Schema.Core.IntegratedCircuit ? Schema.DigitalIntegratedCircuit :
+    T extends Schema.Circuit ? DigitalSchema.DigitalCircuit :
+    T extends Schema.IntegratedCircuit ? DigitalSchema.DigitalIntegratedCircuit :
     // Base-type replacements
     T extends IntegratedCircuit ? DigitalIntegratedCircuit :
     T extends Circuit           ? DigitalCircuit :

--- a/src/projects/digital/api/circuit/src/public/DigitalComponent.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalComponent.ts
@@ -1,8 +1,9 @@
 import {Component, Node, ReadonlyComponent, ReadonlyNode} from "shared/api/circuit/public";
 
+import {Signal} from "digital/api/circuit/schema/Signal";
+
 import {DigitalPort}  from "./DigitalPort";
 import {APIToDigital} from "./DigitalCircuit";
-import {Signal} from "../internal/sim/Signal";
 
 
 export interface ReadonlyDigitalComponent extends APIToDigital<ReadonlyComponent> {

--- a/src/projects/digital/api/circuit/src/public/DigitalPort.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalPort.ts
@@ -2,7 +2,7 @@ import type {Port, ReadonlyPort} from "shared/api/circuit/public";
 
 import type {APIToDigital} from "./DigitalCircuit";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 
 
 export interface ReadonlyDigitalPort extends APIToDigital<ReadonlyPort> {

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
@@ -1,8 +1,9 @@
 import {CircuitImpl, IntegratedCircuitImpl} from "shared/api/circuit/public/impl/Circuit";
+import {Schema} from "shared/api/circuit/schema";
 
 import {APIToDigital, DigitalCircuit, DigitalIntegratedCircuit} from "../DigitalCircuit";
 import {DigitalCircuitState, DigitalTypes} from "./DigitalCircuitState";
-import {Schema} from "../../schema";
+import {DigitalSchema} from "digital/api/circuit/schema";
 import {DigitalComponent} from "../DigitalComponent";
 import {DigitalPort} from "../DigitalPort";
 import {DigitalWire} from "../DigitalWire";
@@ -50,7 +51,7 @@ export class DigitalCircuitImpl extends CircuitImpl<DigitalTypes> implements Dig
     }
 
     public override loadSchema(
-        schema: Schema.DigitalCircuit,
+        schema: DigitalSchema.DigitalCircuit,
         opts?: { refreshIds?: boolean, loadMetadata?: boolean }
     ): Array<DigitalComponent | DigitalWire | DigitalPort> {
         // TODO[] - might need it like this
@@ -81,10 +82,10 @@ export class DigitalCircuitImpl extends CircuitImpl<DigitalTypes> implements Dig
         return objs;
     }
 
-    public override toSchema(container?: ObjContainer): Schema.DigitalCircuit {
+    public override toSchema(container?: ObjContainer): DigitalSchema.DigitalCircuit {
         return {
             // TODO[] - cleanup type cast maybe
-            ...super.toSchema(container) as Schema.Core.Circuit & { ics: Schema.DigitalIntegratedCircuit[] },
+            ...super.toSchema(container) as Schema.Circuit & { ics: DigitalSchema.DigitalIntegratedCircuit[] },
 
             propagationTime: -1, // TODO[model_refactor_api],
 
@@ -103,7 +104,7 @@ export class DigitalIntegratedCircuitImpl extends IntegratedCircuitImpl<DigitalT
         this.state = state;
     }
 
-    public override toSchema(): Schema.DigitalIntegratedCircuit {
+    public override toSchema(): DigitalSchema.DigitalIntegratedCircuit {
         return {
             ...super.toSchema(),
 

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalCircuitState.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalCircuitState.ts
@@ -1,6 +1,6 @@
 import {CircuitState, CircuitTypes} from "shared/api/circuit/public/impl/CircuitState";
 
-import {DigitalCircuit, DigitalICInfo, DigitalIntegratedCircuit} from "../DigitalCircuit";
+import {DigitalCircuit, DigitalICInfo, DigitalIntegratedCircuit, DigitalObjContainer} from "../DigitalCircuit";
 import {DigitalComponent, DigitalNode} from "../DigitalComponent";
 import {DigitalPort}                   from "../DigitalPort";
 import {DigitalWire}                   from "../DigitalWire";
@@ -16,7 +16,8 @@ export type DigitalTypes = CircuitTypes<
     DigitalPort,
     DigitalNode,
     DigitalIntegratedCircuit,
-    DigitalICInfo
+    DigitalICInfo,
+    DigitalObjContainer
 >;
 
 export interface DigitalCircuitState extends CircuitState<DigitalTypes> {

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalComponent.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalComponent.ts
@@ -1,11 +1,12 @@
 import {ComponentImpl} from "shared/api/circuit/public/impl/Component";
+import {GUID}          from "shared/api/circuit/public";
+
+import {Signal} from "digital/api/circuit/schema/Signal";
 
 import {DigitalComponent} from "../DigitalComponent";
 import {DigitalPort}      from "../DigitalPort";
 
 import {DigitalCircuitState, DigitalTypes} from "./DigitalCircuitState";
-import {Signal} from "../../internal/sim/Signal";
-import {GUID} from "shared/api/circuit/public";
 
 
 export class DigitalComponentImpl extends ComponentImpl<DigitalTypes> implements DigitalComponent {

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalPort.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalPort.ts
@@ -1,7 +1,7 @@
 import {GUID}     from "shared/api/circuit/internal";
 import {PortImpl} from "shared/api/circuit/public/impl/Port";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 
 import {DigitalPort} from "../DigitalPort";
 

--- a/src/projects/digital/api/circuit/src/schema/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/schema/DigitalCircuit.ts
@@ -2,16 +2,9 @@ import {Schema} from "shared/api/circuit/schema";
 import {DigitalSimState} from "./DigitalSimState";
 
 
-export interface DigitalIntegratedCircuit extends Schema.IntegratedCircuit {
-    initialSimState: DigitalSimState;
-}
-
 export interface DigitalCircuit extends Schema.Circuit {
-    // Override
-    ics: DigitalIntegratedCircuit[];
-
     propagationTime: number;
 
-    // icSimStates: Record<GUID, DigitalSimState>;
+    initialICSimStates: DigitalSimState[];
     simState: DigitalSimState;
 }

--- a/src/projects/digital/api/circuit/src/schema/DigitalSimState.ts
+++ b/src/projects/digital/api/circuit/src/schema/DigitalSimState.ts
@@ -1,6 +1,5 @@
 import {GUID} from "shared/api/circuit/schema";
-// TODO[model_refactor_api] - define Signal in schema
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "./Signal";
 
 
 export interface DigitalSimState {

--- a/src/projects/digital/api/circuit/src/schema/Signal.ts
+++ b/src/projects/digital/api/circuit/src/schema/Signal.ts
@@ -1,5 +1,3 @@
-
-
 export enum Signal {
     Off        =  0,
     On         =  1,
@@ -37,23 +35,3 @@ export namespace Signal {
         return (s !== Signal.Metastable);
     }
 }
-
-/**
- * Higher-order utility function that creates a signal reducer based on the given boolean reducer.
- *
- * The returned reducer can be used on an array of `Signal`s to reduce to a single `Signal`.
- *  (for use in AND/OR/XOR/etc gates).
- *
- * The reducer will return Metastable if and only if any of the values are Metastable, otherwise it will return
- *  the value of the given boolean reducer, using that `Signal.On` is `true` and `Signal.Off` is `false`.
- *
- * @param func A boolean reducer function to reduce signals that are `On` or `Off`.
- * @returns    A reducer function that can reduce an array of `Signal`s to a single `Signal`.
- */
-export const SignalReducer = (func: (a: boolean, b: boolean) => boolean) => (
-    (a: Signal, b: Signal) => {
-        if (a === Signal.Metastable || b === Signal.Metastable)
-            return Signal.Metastable;
-        return Signal.fromBool(func(Signal.isOn(a), Signal.isOn(b)));
-    }
-);

--- a/src/projects/digital/api/circuit/src/schema/export.ts
+++ b/src/projects/digital/api/circuit/src/schema/export.ts
@@ -1,2 +1,3 @@
 export * from "./DigitalCircuit";
 export * from "./DigitalSimState";
+export * from "./Signal";

--- a/src/projects/digital/api/circuit/src/schema/export.ts
+++ b/src/projects/digital/api/circuit/src/schema/export.ts
@@ -1,3 +1,2 @@
 export * from "./DigitalCircuit";
 export * from "./DigitalSimState";
-export {Schema as Core} from "shared/api/circuit/schema";

--- a/src/projects/digital/api/circuit/src/schema/index.ts
+++ b/src/projects/digital/api/circuit/src/schema/index.ts
@@ -1,5 +1,1 @@
-
-// TODO[model_refactor_api] - call this DigitalSchema instead
-import * as Schema from "./export";
-
-export { Schema };
+export * as DigitalSchema from "./export";

--- a/src/projects/digital/api/circuit/tests/helpers/CreateTestCircuit.ts
+++ b/src/projects/digital/api/circuit/tests/helpers/CreateTestCircuit.ts
@@ -2,7 +2,7 @@ import "./Extensions";
 
 import {CreateCircuit} from "digital/api/circuit/public"
 import {DigitalComponent} from "digital/api/circuit/public/DigitalComponent"
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {V} from "Vector"
 import {DigitalPort} from "digital/api/circuit/public/DigitalPort";
 import {DigitalWire} from "digital/api/circuit/public/DigitalWire";

--- a/src/projects/digital/api/circuit/tests/helpers/Extensions.ts
+++ b/src/projects/digital/api/circuit/tests/helpers/Extensions.ts
@@ -1,4 +1,4 @@
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalComponent} from "digital/api/circuit/public/DigitalComponent";
 
 

--- a/src/projects/digital/api/circuit/tests/sim/FlipFlops.test.ts
+++ b/src/projects/digital/api/circuit/tests/sim/FlipFlops.test.ts
@@ -1,6 +1,6 @@
 import "shared/tests/helpers/Extensions";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {CreateTestCircuit} from "tests/helpers/CreateTestCircuit";
 
 

--- a/src/projects/digital/api/circuit/tests/sim/IC.test.ts
+++ b/src/projects/digital/api/circuit/tests/sim/IC.test.ts
@@ -1,4 +1,4 @@
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import "shared/tests/helpers/Extensions";
 
 import {CreateTestCircuit} from "tests/helpers/CreateTestCircuit";

--- a/src/projects/digital/api/circuit/tests/sim/Latches.test.ts
+++ b/src/projects/digital/api/circuit/tests/sim/Latches.test.ts
@@ -1,6 +1,6 @@
 import "shared/tests/helpers/Extensions";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {CreateTestCircuit} from "tests/helpers/CreateTestCircuit";
 
 

--- a/src/projects/digital/api/circuitdesigner/src/tools/handlers/InteractionHandler.ts
+++ b/src/projects/digital/api/circuitdesigner/src/tools/handlers/InteractionHandler.ts
@@ -5,7 +5,7 @@ import {CircleContains, RectContains} from "math/MathUtils";
 import {LEFT_MOUSE_BUTTON}                from "shared/api/circuitdesigner/input/Constants";
 import {ToolHandler, ToolHandlerResponse} from "shared/api/circuitdesigner/tools/handlers/ToolHandler";
 
-import {Signal}           from "digital/api/circuit/internal/sim/Signal";
+import {Signal}           from "digital/api/circuit/schema/Signal";
 import {DigitalComponent} from "digital/api/circuit/public/DigitalComponent";
 import {DigitalTypes}     from "digital/api/circuit/public/impl/DigitalCircuitState";
 

--- a/src/projects/digital/site/src/containers/ICViewer/index.tsx
+++ b/src/projects/digital/site/src/containers/ICViewer/index.tsx
@@ -129,12 +129,14 @@ export const ICViewer = () => {
                 obj.kind = "LED";
         }
         circuit.loadSchema({
-            metadata:        schema.metadata,
-            objects:         schema.objects,
-            ics:             mainDesigner.circuit.toSchema().ics,
-            camera:          { x: 0, y: 0, zoom: 0.02 },
-            propagationTime: mainDesigner.circuit.propagationTime,
-            simState:        schema.initialSimState,
+            metadata: schema.metadata,
+            objects:  schema.objects,
+            ics:      mainDesigner.circuit.toSchema().ics,
+            camera:   { x: 0, y: 0, zoom: 0.02 },
+
+            propagationTime:    mainDesigner.circuit.propagationTime,
+            initialICSimStates: mainDesigner.circuit.getICs().map((ic) => ic.initialSimState),
+            simState:           ic.initialSimState,
         });
         // TODO[model_refactor_api]
         // Adjust the camera so it all fits in the viewer

--- a/src/projects/digital/site/src/index.tsx
+++ b/src/projects/digital/site/src/index.tsx
@@ -60,7 +60,7 @@ import {CreateCircuit} from "digital/api/circuit/public";
 import {DRAG_TIME} from "shared/api/circuitdesigner/input/Constants";
 import {TimedDigitalSimRunner} from "digital/api/circuit/internal/sim/TimedDigitalSimRunner";
 import {DigitalProtoToSchema, DigitalSchemaToProto} from "digital/site/proto/bridge";
-import {Schema} from "digital/api/circuit/schema";
+import {DigitalSchema} from "digital/api/circuit/schema";
 
 
 async function Init(): Promise<void> {
@@ -166,7 +166,7 @@ async function Init(): Promise<void> {
                 SerializeCircuit(circuit) {
                     return new Blob([
                         DigitalProtoSchema.DigitalCircuit.encode(
-                            DigitalSchemaToProto(circuit as Schema.DigitalCircuit)
+                            DigitalSchemaToProto(circuit as DigitalSchema.DigitalCircuit)
                         ).finish(),
                     ]);
                 },

--- a/src/projects/digital/site/src/proto/bridge.ts
+++ b/src/projects/digital/site/src/proto/bridge.ts
@@ -4,7 +4,7 @@
 import {MapObj} from "shared/api/circuit/utils/Functions";
 
 import {DigitalSchema} from "digital/api/circuit/schema";
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 
 import {ProtoToSchema, SchemaToProto} from "shared/site/proto/bridge";
 

--- a/src/projects/digital/site/src/proto/bridge.ts
+++ b/src/projects/digital/site/src/proto/bridge.ts
@@ -34,7 +34,7 @@ export function DigitalSchemaToProto(schema: DigitalSchema.DigitalCircuit): Digi
         circuit: SchemaToProto(schema),
 
         propagationTime:    schema.propagationTime,
-        icInitialSimStates: schema.ics.map((ic) => ConvertSimState(ic.initialSimState)),
+        icInitialSimStates: schema.initialICSimStates.map(ConvertSimState),
         simState:           ConvertSimState(schema.simState),
     });
 }
@@ -68,12 +68,8 @@ export function DigitalProtoToSchema(proto: DigitalProtoSchema.DigitalCircuit): 
     return {
         ...schema,
 
-        ics: schema.ics.zip(proto.icInitialSimStates).map(([ic, sim]) => ({
-            ...ic,
-            initialSimState: ConvertSimState(sim),
-        })),
-
-        propagationTime: proto.propagationTime,
-        simState:        ConvertSimState(proto.simState),
+        initialICSimStates: proto.icInitialSimStates.map(ConvertSimState),
+        propagationTime:    proto.propagationTime,
+        simState:           ConvertSimState(proto.simState),
     }
 }

--- a/src/projects/digital/site/src/proto/bridge.ts
+++ b/src/projects/digital/site/src/proto/bridge.ts
@@ -3,7 +3,7 @@
 
 import {MapObj} from "shared/api/circuit/utils/Functions";
 
-import {Schema} from "digital/api/circuit/schema";
+import {DigitalSchema} from "digital/api/circuit/schema";
 import {Signal} from "digital/api/circuit/internal/sim/Signal";
 
 import {ProtoToSchema, SchemaToProto} from "shared/site/proto/bridge";
@@ -11,7 +11,7 @@ import {ProtoToSchema, SchemaToProto} from "shared/site/proto/bridge";
 import * as DigitalProtoSchema from "./DigitalCircuit";
 
 
-export function DigitalSchemaToProto(schema: Schema.DigitalCircuit): DigitalProtoSchema.DigitalCircuit {
+export function DigitalSchemaToProto(schema: DigitalSchema.DigitalCircuit): DigitalProtoSchema.DigitalCircuit {
     function ConvertSignal(signal: Signal): DigitalProtoSchema.DigitalSimState_Signal {
         return (signal === Signal.On
             ? DigitalProtoSchema.DigitalSimState_Signal.On
@@ -22,7 +22,7 @@ export function DigitalSchemaToProto(schema: Schema.DigitalCircuit): DigitalProt
             : DigitalProtoSchema.DigitalSimState_Signal.UNRECOGNIZED);
     }
 
-    function ConvertSimState(state: Schema.DigitalSimState): DigitalProtoSchema.DigitalSimState {
+    function ConvertSimState(state: DigitalSchema.DigitalSimState): DigitalProtoSchema.DigitalSimState {
         return {
             signals:  MapObj(state.signals,  ([_id, signal]) => ConvertSignal(signal)),
             states:   MapObj(state.states,   ([_id, state])  => ({ state: state.map(ConvertSignal) })),
@@ -39,7 +39,7 @@ export function DigitalSchemaToProto(schema: Schema.DigitalCircuit): DigitalProt
     });
 }
 
-export function DigitalProtoToSchema(proto: DigitalProtoSchema.DigitalCircuit): Schema.DigitalCircuit {
+export function DigitalProtoToSchema(proto: DigitalProtoSchema.DigitalCircuit): DigitalSchema.DigitalCircuit {
     function ConvertSignal(signal: DigitalProtoSchema.DigitalSimState_Signal): Signal {
         return (signal === DigitalProtoSchema.DigitalSimState_Signal.On
             ? Signal.On
@@ -50,7 +50,7 @@ export function DigitalProtoToSchema(proto: DigitalProtoSchema.DigitalCircuit): 
             : Signal.Off);
     }
 
-    function ConvertSimState(state: DigitalProtoSchema.DigitalSimState): Schema.DigitalSimState {
+    function ConvertSimState(state: DigitalProtoSchema.DigitalSimState): DigitalSchema.DigitalSimState {
         return {
             signals:  MapObj(state.signals,  ([_id, signal]) => ConvertSignal(signal)),
             states:   MapObj(state.states,   ([_id, state])  => state.state.map(ConvertSignal)),

--- a/src/projects/digital/site/src/tools/renderers/DigitalWiringToolRenderer.ts
+++ b/src/projects/digital/site/src/tools/renderers/DigitalWiringToolRenderer.ts
@@ -1,5 +1,5 @@
 import {DigitalPort} from "digital/api/circuit/public/DigitalPort";
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 
 import {WiringToolRenderer} from "shared/api/circuitdesigner/tools/renderers/WiringToolRenderer";
 

--- a/src/projects/digital/site/src/utils/DigitalVersionConflictResolver.ts
+++ b/src/projects/digital/site/src/utils/DigitalVersionConflictResolver.ts
@@ -1,6 +1,6 @@
 /* eslint-disable key-spacing */
 import {Signal} from "digital/api/circuit/internal/sim/Signal";
-import {Schema as DigitalSchema} from "digital/api/circuit/schema";
+import {DigitalSchema} from "digital/api/circuit/schema";
 import {Schema} from "shared/api/circuit/schema";
 import {IMPORT_IC_CLOCK_MESSAGE} from "./Constants";
 
@@ -187,10 +187,10 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
         // Helper function to generate connection between old ref string and new digital port, used to later connect wires
         const linkPorts = (
             { ref, obj: port }: {ref?: string, obj: SerializationEntry},
-            portInfo: Omit<DigitalSchema.Core.Port, "baseKind" | "id" | "props" | "kind">,
-        ): DigitalSchema.Core.Port => {
+            portInfo: Omit<Schema.Port, "baseKind" | "id" | "props" | "kind">,
+        ): Schema.Port => {
             const guid = refToGuid.get(ref) ?? Schema.uuid();
-            const props: DigitalSchema.Core.Port["props"] = {};
+            const props: Schema.Port["props"] = {};
             const portName = port["data"]["name"];
             if (typeof portName === "string") {
                 props["name"] = portName;
@@ -207,9 +207,9 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
                 id: guid,
             }
         };
-        const newPorts: DigitalSchema.Core.Port[] = [];
+        const newPorts: Schema.Port[] = [];
         // First map components (and get ports)
-        const newComponents = objs.map(({ obj, ref }, index): DigitalSchema.Core.Component => {
+        const newComponents = objs.map(({ obj, ref }, index): Schema.Component => {
             // Copy common props
             const transformRef = getEntry(obj, "transform")!;
             const posRef = getEntry(transformRef, "pos")!;
@@ -217,7 +217,7 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
             const nameRef = getEntry(obj, "name")!
             const nameData = nameRef.data as { name: unknown, set: unknown };
             // Scale x/y and flip y-axis
-            const props: DigitalSchema.Core.Component["props"] = {
+            const props: Schema.Component["props"] = {
                 zIndex: index,
             };
             if (typeof x === "number") {
@@ -427,7 +427,7 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
         });
 
         const wires = getArrayEntries(wiresEntry);
-        const newWires = wires.map(({ obj, ref }): DigitalSchema.Core.Wire => {
+        const newWires = wires.map(({ obj, ref }): Schema.Wire => {
             // Find connecting port guids
             const p1 = (obj.data.p1 as Ref).ref;
             const newPort1 = refToGuid.get(p1)!;
@@ -435,7 +435,7 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
             const newPort2 = refToGuid.get(p2)!;
 
             // Handle common props
-            const props: DigitalSchema.Core.Wire["props"] = {};
+            const props: Schema.Wire["props"] = {};
             const nameRef = getEntry(obj, "name")!
             const nameData = nameRef.data as { name: string, set: boolean };
             if (nameData.set) {
@@ -612,7 +612,7 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
         const inputPorts = getArrayEntries(getArrayEntry(obj, "inputPorts")!).toSorted(comparePortPos);
         // inputs and their ports are (presumably) linked on index, so when sorting they need to be zipped together
         const inputsAndPorts = inputs.zip(inputPorts).toSorted((a, b) => comparePortPos(a[1], b[1], true));
-        const inputPins = inputsAndPorts.map(([{ ref }, { obj }]): DigitalSchema.Core.IntegratedCircuitPin => {
+        const inputPins = inputsAndPorts.map(([{ ref }, { obj }]): Schema.IntegratedCircuitPin => {
             const origin = getEntry(obj, "origin")!;
             const { x, y } = origin.data as {x: number, y: number};
             const dir = getEntry(obj, "dir")!;
@@ -631,7 +631,7 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
         const outputs = getArrayEntries(getArrayEntry(icContents, "outputs")!);
         const outputPorts = getArrayEntries(getArrayEntry(obj, "outputPorts")!);
         const outputsAndPorts = outputs.zip(outputPorts).toSorted((a, b) => comparePortPos(a[1], b[1], true));
-        const outputPins = outputsAndPorts.map(([{ ref }, { obj }]): DigitalSchema.Core.IntegratedCircuitPin => {
+        const outputPins = outputsAndPorts.map(([{ ref }, { obj }]): Schema.IntegratedCircuitPin => {
             const origin = getEntry(obj, "origin")!;
             const { x, y } = origin.data as {x: number, y: number};
             const dir = getEntry(obj, "dir")!;
@@ -647,7 +647,7 @@ export function VersionConflictResolver(fileContents: string): VersionConflictRe
             }
         });
 
-        const metadata: DigitalSchema.Core.IntegratedCircuitMetadata = {
+        const metadata: Schema.IntegratedCircuitMetadata = {
             displayWidth: w / 50,
             displayHeight: h / 50,
             id: icGuids[index][0],

--- a/src/projects/digital/site/src/utils/DigitalVersionConflictResolver.ts
+++ b/src/projects/digital/site/src/utils/DigitalVersionConflictResolver.ts
@@ -1,5 +1,5 @@
 /* eslint-disable key-spacing */
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalSchema} from "digital/api/circuit/schema";
 import {Schema} from "shared/api/circuit/schema";
 import {IMPORT_IC_CLOCK_MESSAGE} from "./Constants";

--- a/src/projects/digital/site/tests/containers/ExprToCircuitPopup.test.tsx
+++ b/src/projects/digital/site/tests/containers/ExprToCircuitPopup.test.tsx
@@ -21,7 +21,7 @@ import {CreateDesigner} from "digital/api/circuitdesigner/DigitalCircuitDesigner
 import {DefaultTool} from "shared/api/circuitdesigner/tools/DefaultTool";
 import {V} from "Vector";
 import {configureStore} from "@reduxjs/toolkit";
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {InstantSimRunner} from "digital/api/circuit/internal/sim/DigitalSimRunner";
 
 

--- a/src/projects/digital/site/tests/utils/DigitalVersionConflictResolver.test.ts
+++ b/src/projects/digital/site/tests/utils/DigitalVersionConflictResolver.test.ts
@@ -1,7 +1,7 @@
 import "digital/api/circuit/tests/helpers/Extensions";
 import "shared/tests/helpers/Extensions";
 
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {VersionConflictResolver} from "digital/site/utils/DigitalVersionConflictResolver";
 import {V} from "Vector";
 

--- a/src/projects/digital/site/tests/utils/ExpressionParser.test.ts
+++ b/src/projects/digital/site/tests/utils/ExpressionParser.test.ts
@@ -8,7 +8,7 @@ import {GenerateInputTree} from "digital/site/utils/ExpressionParser/GenerateInp
 import {ExpressionToCircuit} from "digital/site/utils/ExpressionParser";
 import {GenerateTokens}      from "digital/site/utils/ExpressionParser/GenerateTokens";
 import {FORMATS}             from "digital/site/utils/ExpressionParser/Constants/Formats";
-import {Signal} from "digital/api/circuit/internal/sim/Signal";
+import {Signal} from "digital/api/circuit/schema/Signal";
 import {DigitalComponent} from "digital/api/circuit/public/DigitalComponent";
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 import {InstantSimRunner} from "digital/api/circuit/internal/sim/DigitalSimRunner";

--- a/src/projects/shared/api/circuit/src/public/impl/Circuit.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Circuit.ts
@@ -48,7 +48,7 @@ export class HistoryImpl extends ObservableImpl<CircuitHistoryEvent> implements 
 export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitEvent> implements Circuit {
     protected readonly state: CircuitState<T>;
 
-    public readonly selections: Selections;
+    public readonly selections: SelectionsImpl<T>;
     public readonly history: CircuitHistory;
 
     public constructor(state: CircuitState<T>) {
@@ -56,7 +56,7 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
 
         this.state = state;
 
-        this.selections = new SelectionsImpl(state);
+        this.selections = new SelectionsImpl<T>(state);
         this.history = new HistoryImpl(state.internal);
 
         // This ordering is important, because it means that all previous circuit subscription calls will happen
@@ -170,7 +170,7 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
         return this.state.constructComponentInfo(kind);
     }
 
-    public createContainer(objs: GUID[]): ObjContainer {
+    public createContainer(objs: GUID[]): T["ObjContainerT"] {
         const objSet = new Set(objs);
 
         // Validate all objects exist in the circuit
@@ -310,7 +310,7 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
 
         return objs.map((id) => this.getObj(id)!);
     }
-    public toSchema(container?: ObjContainer): Schema.Circuit {
+    public toSchema(container?: T["ObjContainerT"]): Schema.Circuit {
         const ics = container?.ics ?? this.getICs();
         const objs = container?.all ?? this.getObjs();
 

--- a/src/projects/shared/api/circuit/src/public/impl/CircuitState.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/CircuitState.ts
@@ -6,6 +6,7 @@ import {Component, Node}   from "../Component";
 import {Port}              from "../Port";
 import {Wire}              from "../Wire";
 import {Circuit, ICInfo, IntegratedCircuit} from "../Circuit";
+import {ObjContainer} from "../ObjContainer";
 
 
 // Utility interface to hold utility types for the templated Circuit API.
@@ -17,6 +18,7 @@ export type CircuitTypes<
     NodeT extends Node = Node,
     ICT extends IntegratedCircuit = IntegratedCircuit,
     ICInfoT extends ICInfo = ICInfo,
+    ObjContainerT extends ObjContainer = ObjContainer,
 > = {
     "Circuit": CircuitT;
 
@@ -39,6 +41,7 @@ export type CircuitTypes<
     "IC[]": ICT[];
 
     "ICInfo": ICInfoT;
+    "ObjContainerT": ObjContainerT;
 }
 
 export interface CircuitState<T extends CircuitTypes> {

--- a/src/projects/shared/api/circuit/src/public/impl/ObjContainer.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/ObjContainer.ts
@@ -7,7 +7,6 @@ import {ObjContainer} from "../ObjContainer";
 import {CircuitState, CircuitTypes} from "./CircuitState";
 
 import "shared/api/circuit/utils/Array";
-import {Schema} from "../../schema";
 
 
 export class ObjContainerImpl<T extends CircuitTypes> implements ObjContainer {
@@ -85,7 +84,7 @@ export class ObjContainerImpl<T extends CircuitTypes> implements ObjContainer {
             .map((id) => this.state.constructIC(id));
     }
 
-    public withWiresAndPorts(): ObjContainer {
+    public withWiresAndPorts(): T["ObjContainerT"] {
         const comps = this.components;
         const ports = [
             ...this.ports,

--- a/src/projects/shared/api/circuit/src/public/impl/Selections.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Selections.ts
@@ -72,7 +72,7 @@ export class SelectionsImpl<T extends CircuitTypes> extends ObservableImpl<Selec
         return this.selections.ics;
     }
 
-    public withWiresAndPorts(): ObjContainer {
+    public withWiresAndPorts(): T["ObjContainerT"] {
         return this.selections.withWiresAndPorts();
     }
 


### PR DESCRIPTION
- Moved Signal def to DigitalSchema
- Changed all digital schema references to `DigitalSchema.` and changed all `Schema.Core.` to just `Schema.`
- Removed `DigitalSchema.DigitalIntegratedCircuit` and added IC initial states as an array in the `DigitalSchema.DigitalCircuit`