### PR TITLE
Rest of the selection popup props (except clock/oscilloscope pause button)

### DIFF
--- a/src/projects/digital/api/circuit/src/internal/assembly/components/OscilloscopeAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/OscilloscopeAssembler.ts
@@ -33,7 +33,7 @@ export class OscilloscopeAssembler extends ComponentAssembler {
             {
                 kind: "BaseShape",
 
-                dependencies: new Set([AssemblyReason.TransformChanged, AssemblyReason.PortsChanged]),
+                dependencies: new Set([AssemblyReason.TransformChanged, AssemblyReason.PropChanged, AssemblyReason.PortsChanged]),
                 assemble:     (comp) => ({
                     kind:      "Rectangle",
                     transform: this.getTransform(comp),

--- a/src/projects/digital/api/circuit/src/internal/assembly/components/displays/BaseDisplayAssembler.ts
+++ b/src/projects/digital/api/circuit/src/internal/assembly/components/displays/BaseDisplayAssembler.ts
@@ -51,7 +51,7 @@ export abstract class BaseDisplayAssembler extends ComponentAssembler {
             {
                 kind: "BaseShape",
 
-                dependencies: new Set([AssemblyReason.TransformChanged, AssemblyReason.SignalsChanged, AssemblyReason.PortsChanged]),
+                dependencies: new Set([AssemblyReason.TransformChanged, AssemblyReason.SignalsChanged, AssemblyReason.PortsChanged, AssemblyReason.PropChanged]),
                 assemble:     (comp) => this.assembleSegments(comp, false),
 
                 styleChangesWhenSelected: true,
@@ -60,7 +60,7 @@ export abstract class BaseDisplayAssembler extends ComponentAssembler {
             {
                 kind: "BaseShape",
 
-                dependencies: new Set([AssemblyReason.TransformChanged, AssemblyReason.SignalsChanged, AssemblyReason.PortsChanged]),
+                dependencies: new Set([AssemblyReason.TransformChanged, AssemblyReason.SignalsChanged, AssemblyReason.PortsChanged, AssemblyReason.PropChanged]),
                 assemble:     (comp) => this.assembleSegments(comp, true),
 
                 styleChangesWhenSelected: true,

--- a/src/projects/digital/site/src/containers/App/index.tsx
+++ b/src/projects/digital/site/src/containers/App/index.tsx
@@ -91,6 +91,16 @@ export const App = () => {
                             kinds={new Set(["Comparator"])}
                             basisPortGroup="inputsA"
                             label="Input" />
+                        <PortCountModule
+                            circuit={designer.circuit}
+                            kinds={new Set(["SegmentDisplay"])}
+                            basisPortGroup="inputs"
+                            label="Segment" />
+                        <PortCountModule
+                            circuit={designer.circuit}
+                            kinds={new Set(["Oscilloscope"])}
+                            basisPortGroup="inputs"
+                            label="Input" />
                         <OscilloscopeModule circuit={designer.circuit} />
                         <ClockSyncButtonModule circuit={designer.circuit} />
                         <BusButtonModule circuit={designer.circuit} />

--- a/src/projects/digital/site/src/containers/SelectionPopup/modules/PortCountModule.tsx
+++ b/src/projects/digital/site/src/containers/SelectionPopup/modules/PortCountModule.tsx
@@ -14,7 +14,6 @@ type Props = {
     label: string;
 }
 export const PortCountModule = ({ circuit, kinds, basisPortGroup, label }: Props) => {
-    // TODO: this
     const [props, comps] = useSelectionProps(
         circuit,
         (c): c is Component => (

--- a/src/projects/digital/site/src/containers/SelectionPopup/propinfo/index.ts
+++ b/src/projects/digital/site/src/containers/SelectionPopup/propinfo/index.ts
@@ -14,8 +14,28 @@ export const DigitalPropInfo: PropInfoRecord = {
     "Switch":         DefaultComponentPropInfo,
     "ConstantLow":    DefaultComponentPropInfo,
     "ConstantHigh":   DefaultComponentPropInfo,
-    "ConstantNumber": DefaultComponentPropInfo,
-    "Clock":          DefaultComponentPropInfo,
+    "ConstantNumber": [
+        ...DefaultComponentPropInfo,
+        {
+            id:      "inputNum",
+            type:    "int",
+            key:     "inputNum",
+            label:   "Input Number",
+            min:     0,
+            max:     15,
+            default: 0,
+        },
+    ],
+    "Clock": [
+        ...DefaultComponentPropInfo,
+        {
+            id:      "delay",
+            type:    "int",
+            key:     "delay",
+            label:   "Delay",
+            default: 250,
+        },
+    ],
 
     // Outputs
     "LED": [
@@ -29,9 +49,67 @@ export const DigitalPropInfo: PropInfoRecord = {
         },
     ],
     "SegmentDisplay": DefaultComponentPropInfo,
-    "BCDDisplay":     DefaultComponentPropInfo,
-    "ASCIIDisplay":   DefaultComponentPropInfo,
-    "Oscilloscope":   DefaultComponentPropInfo,
+    "BCDDisplay":     [
+        ...DefaultComponentPropInfo,
+        {
+            id:      "segmentCount",
+            type:    "number[]",
+            key:     "segmentCount",
+            label:   "Segment Count",
+            options: [
+                ["7", 7],
+                ["9", 9],
+                ["14", 14],
+                ["16", 16],
+            ],
+            default: 7,
+        },
+    ],
+    "ASCIIDisplay": [
+        ...DefaultComponentPropInfo,
+        {
+            id:      "segmentCount",
+            type:    "number[]",
+            key:     "segmentCount",
+            label:   "Segment Count",
+            options: [
+                ["7", 7],
+                ["9", 9],
+                ["14", 14],
+                ["16", 16],
+            ],
+            default: 7,
+        },
+    ],
+    "Oscilloscope": [
+        ...DefaultComponentPropInfo,
+        {
+            id:      "samples",
+            type:    "int",
+            key:     "samples",
+            label:   "Samples",
+            min:     10,
+            max:     400,
+            default: 100,
+        },
+        {
+            id:      "w",
+            type:    "int",
+            key:     "w",
+            label:   "Display Size",
+            min:     2,
+            max:     20,
+            default: 8,
+        },
+        {
+            id:      "h",
+            type:    "int",
+            key:     "h",
+            min:     1,
+            max:     10,
+            default: 4,
+        },
+    ],
 
     // Logic Gates
     "BUFGate":  DefaultComponentPropInfo,

--- a/src/projects/shared/site/src/containers/SelectionPopup/modules/PropertyModule.tsx
+++ b/src/projects/shared/site/src/containers/SelectionPopup/modules/PropertyModule.tsx
@@ -124,6 +124,19 @@ const PropInfoEntryInputField = ({
                     step={entry.step} min={entry.min} max={entry.max}
                     doChange={doChange} />
             );
+        case "number[]":
+            return (
+                <SelectModuleInputField
+                    circuit={circuit}
+                    kind="number[]"
+                    props={vals as number[]} options={entry.options}
+                    doChange={doChange}
+                    onSubmit={() => {
+                        // TODO[model_refactor_api](leon) - do we still need this?
+                        forceUpdate(); // Need to force update since these can trigger info-state changes
+                        //  and feel less inituitive to the user about focus/blur
+                    }} />
+            );
         case "string":
             return (
                 <TextModuleInputField

--- a/src/projects/shared/site/src/containers/SelectionPopup/propinfo/PropInfo.ts
+++ b/src/projects/shared/site/src/containers/SelectionPopup/propinfo/PropInfo.ts
@@ -23,6 +23,14 @@ export type NumberPropInfo = BaseFieldPropInfo & {
         (v: number) => number, // Inverse transform
     ];
 }
+export type NumberSelectPropInfo = BaseFieldPropInfo & {
+    type: "number[]";
+    options: Array<[
+        string, // Display value
+        number, // Option value
+    ]>;
+    default?: number;
+}
 export type StringPropInfo = BaseFieldPropInfo & {
     type: "string";
     default?: string;
@@ -48,6 +56,7 @@ export type GroupPropInfo = BasePropInfo & {
 
 export type PropInfoEntryField =
     | NumberPropInfo
+    | NumberSelectPropInfo
     | StringSelectPropInfo
     | ColorPropInfo
     | StringPropInfo

--- a/src/projects/shared/site/src/containers/SelectionPopup/propinfo/PropUtils.ts
+++ b/src/projects/shared/site/src/containers/SelectionPopup/propinfo/PropUtils.ts
@@ -8,6 +8,7 @@ export const DefaultEntryFieldDefaults = {
     "float":    0,
     "string":   "",
     "string[]": "",
+    "number[]": 0,
     "color":    "#000000",
 } as const;
 


### PR DESCRIPTION
Oscilloscope assembler needs some work it seems:

- [ ] Changing display size isn't updating the rectangle until you move it
- [ ] Decreasing samples allows the graph to extend past the end of the oscilloscope
- [ ] Ports aren't positioned properly (with multiple input ports)