### PR TITLE
Made decision around wire vs internal rep

### DIFF
--- a/src/projects/digital/api/circuit/src/internal/DigitalComponents.ts
+++ b/src/projects/digital/api/circuit/src/internal/DigitalComponents.ts
@@ -357,13 +357,13 @@ export class DigitalObjInfoProvider extends BaseObjInfoProvider {
         const portGroupInfo = MapObj(ports, ([_, pins]) => {
             // Verify all the pins in this group belong to the same type (input/output)
             const pinObjs = pins
-                .map(({ id }) => ic.objects.find((o) => (o.id === id)));
-            if (!pinObjs.every((o) => !!o && o.baseKind === "Port")) {
+                .map(({ id }) => ic.ports.find((o) => (o.id === id)));
+            if (pinObjs.some((o) => !o)) {
                 throw new Error(
-                    `DigitalObjInfoProvider.onICCreate: found undefined or non-Port pins for IC ${ic.metadata.id}!`);
+                    `DigitalObjInfoProvider.onICCreate: found undefined pins for IC ${ic.metadata.id}!`);
             }
             const portObjs = pinObjs as Schema.Port[];
-            const parentObjs = portObjs.map((p) => ic.objects.find((o) => (o.id === p.parent))! as Schema.Component);
+            const parentObjs = portObjs.map((p) => ic.comps.find((o) => (o.id === p.parent))!);
             const types = parentObjs.map((c, i) => this.getComponent(c.kind)!.portGroupInfo[portObjs[i].group]);
             if (!types.every((type) => (type === types[0]))) {
                 throw new Error(

--- a/src/projects/digital/api/circuit/src/internal/sim/DigitalSim.ts
+++ b/src/projects/digital/api/circuit/src/internal/sim/DigitalSim.ts
@@ -4,7 +4,7 @@ import {MapObj}                 from "shared/api/circuit/utils/Functions";
 import {CircuitInternal, GUID}  from "shared/api/circuit/internal";
 import {ReadonlyCircuitStorage} from "shared/api/circuit/internal/impl/CircuitDocument";
 import {Schema}                 from "shared/api/circuit/schema";
-import {ObjContainer}           from "shared/api/circuit/public/ObjContainer";
+import {ObjContainer, ReadonlyObjContainer}           from "shared/api/circuit/public/ObjContainer";
 
 import {DigitalSchema} from "digital/api/circuit/schema";
 import {Signal}        from "digital/api/circuit/schema/Signal";
@@ -182,7 +182,7 @@ class DigitalSimState<M extends Schema.CircuitMetadata = Schema.CircuitMetadata>
         return this.icStates.get(icInstance.id)!.findState(rest);
     }
 
-    public toSchema(container?: ObjContainer): DigitalSchema.DigitalSimState {
+    public toSchema(container?: ReadonlyObjContainer): DigitalSchema.DigitalSimState {
         const compIds = container?.components.map((c) => c.id);
 
         const signalKeys = container?.ports.map((p) => p.id) ?? this.signals.keys();

--- a/src/projects/digital/api/circuit/src/internal/sim/DigitalSim.ts
+++ b/src/projects/digital/api/circuit/src/internal/sim/DigitalSim.ts
@@ -4,7 +4,7 @@ import {MapObj}                 from "shared/api/circuit/utils/Functions";
 import {CircuitInternal, GUID}  from "shared/api/circuit/internal";
 import {ReadonlyCircuitStorage} from "shared/api/circuit/internal/impl/CircuitDocument";
 import {Schema}                 from "shared/api/circuit/schema";
-import {ObjContainer, ReadonlyObjContainer}           from "shared/api/circuit/public/ObjContainer";
+import {ReadonlyObjContainer}   from "shared/api/circuit/public/ObjContainer";
 
 import {DigitalSchema} from "digital/api/circuit/schema";
 import {Signal}        from "digital/api/circuit/schema/Signal";
@@ -401,7 +401,7 @@ export class DigitalSim extends ObservableImpl<DigitalSimEvent> {
 
                 comps, updatedInputPorts,
             });
-        })
+        });
     }
 
     public loadState(state: DigitalSchema.DigitalSimState) {

--- a/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
@@ -24,7 +24,7 @@ import type {DigitalComponent, DigitalNode, ReadonlyDigitalComponent, ReadonlyDi
 import type {DigitalWire, ReadonlyDigitalWire}                   from "./DigitalWire";
 import type {DigitalPort, ReadonlyDigitalPort}                   from "./DigitalPort";
 import type {DigitalSchema} from "digital/api/circuit/schema";
-import {ObjContainer} from "shared/api/circuit/public/ObjContainer";
+import type {ObjContainer, ReadonlyObjContainer} from "shared/api/circuit/public/ObjContainer";
 
 
 export type ToDigital<T> = (
@@ -45,11 +45,12 @@ export type ToDigital<T> = (
     T extends Selections        ? APIToDigital<Selections> :
     T extends ObjContainer      ? DigitalObjContainer :
     // Base-Readonly-type replacements
-    T extends ReadonlyCircuit   ? ReadonlyDigitalCircuit :
-    T extends ReadonlyNode      ? ReadonlyDigitalNode :
-    T extends ReadonlyComponent ? ReadonlyDigitalComponent :
-    T extends ReadonlyWire      ? ReadonlyDigitalWire :
-    T extends ReadonlyPort      ? ReadonlyDigitalPort :
+    T extends ReadonlyCircuit      ? ReadonlyDigitalCircuit :
+    T extends ReadonlyNode         ? ReadonlyDigitalNode :
+    T extends ReadonlyComponent    ? ReadonlyDigitalComponent :
+    T extends ReadonlyWire         ? ReadonlyDigitalWire :
+    T extends ReadonlyPort         ? ReadonlyDigitalPort :
+    T extends ReadonlyObjContainer ? ReadonlyDigitalObjContainer :
     // Replace all method args/return types
     T extends (...a: infer Args) => infer R ? (...a: ToDigital<Args>) => ToDigital<R> :
     // Recursively replace records
@@ -64,6 +65,7 @@ export type APIToDigital<T> = {
     [key in keyof T]: ToDigital<T[key]>;
 }
 
+export type ReadonlyDigitalObjContainer = APIToDigital<ReadonlyObjContainer>;
 export type DigitalObjContainer = APIToDigital<ObjContainer>;
 
 export type ReadonlyDigitalCircuit = APIToDigital<ReadonlyCircuit>;

--- a/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
@@ -72,7 +72,7 @@ export type ReadonlyDigitalCircuit = APIToDigital<ReadonlyCircuit>;
 export type DigitalCircuit = APIToDigital<Circuit> & ReadonlyDigitalCircuit & {
     propagationTime: number;
 
-    // TODO: Make an API-specific wrapper for this
+    // TODO[model_refactor_api]: Make an API-specific wrapper for this
     readonly simState: DigitalSchema.DigitalSimState;
 
     step(): void;

--- a/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalCircuit.ts
@@ -72,6 +72,9 @@ export type ReadonlyDigitalCircuit = APIToDigital<ReadonlyCircuit>;
 export type DigitalCircuit = APIToDigital<Circuit> & ReadonlyDigitalCircuit & {
     propagationTime: number;
 
+    // TODO: Make an API-specific wrapper for this
+    readonly simState: DigitalSchema.DigitalSimState;
+
     step(): void;
 };
 

--- a/src/projects/digital/api/circuit/src/public/DigitalComponent.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalComponent.ts
@@ -2,26 +2,27 @@ import {Component, Node, ReadonlyComponent, ReadonlyNode} from "shared/api/circu
 
 import {Signal} from "digital/api/circuit/schema/Signal";
 
-import {DigitalPort}  from "./DigitalPort";
+import {DigitalPort, ReadonlyDigitalPort}  from "./DigitalPort";
 import {APIToDigital} from "./DigitalCircuit";
 
 
-export interface ReadonlyDigitalComponent extends APIToDigital<ReadonlyComponent> {
-    readonly inputs: DigitalPort[];
-    readonly outputs: DigitalPort[];
+interface BaseReadonlyDigitalComponent<P, N> {
+    readonly inputs: P[];
+    readonly outputs: P[];
 
-    isNode(): this is DigitalNode;
+    isNode(): this is N;
 }
-type C = APIToDigital<Component> & ReadonlyDigitalComponent;
-export interface DigitalComponent extends C {
-    readonly inputs: DigitalPort[];
-    readonly outputs: DigitalPort[];
 
+export type ReadonlyDigitalComponent = APIToDigital<ReadonlyComponent> &
+    BaseReadonlyDigitalComponent<ReadonlyDigitalPort, ReadonlyDigitalNode>;
+
+
+export type DigitalComponent = APIToDigital<Component> &
+    BaseReadonlyDigitalComponent<DigitalPort, DigitalNode> & {
     // TODO: Is this too much to expose?
     setSimState(state: Signal[]): void;
-
-    isNode(): this is DigitalNode;
 }
+
 
 type ReadonlyDigitalNodeBase = (APIToDigital<ReadonlyNode> & ReadonlyDigitalComponent);
 export interface ReadonlyDigitalNode extends ReadonlyDigitalNodeBase {}

--- a/src/projects/digital/api/circuit/src/public/DigitalPort.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalPort.ts
@@ -5,7 +5,7 @@ import type {APIToDigital} from "./DigitalCircuit";
 import {Signal} from "digital/api/circuit/schema/Signal";
 
 
-export interface ReadonlyDigitalPort extends APIToDigital<ReadonlyPort> {
+interface BaseDigitalPort {
     readonly isInputPort: boolean;
     readonly isOutputPort: boolean;
 
@@ -22,21 +22,7 @@ export interface ReadonlyDigitalPort extends APIToDigital<ReadonlyPort> {
      */
     readonly isAvailable: boolean;
 }
-type P = APIToDigital<Port> & ReadonlyDigitalPort;
-export interface DigitalPort extends P {
-    readonly isInputPort: boolean;
-    readonly isOutputPort: boolean;
 
-    readonly signal: Signal;
+export type ReadonlyDigitalPort = APIToDigital<ReadonlyPort> & BaseDigitalPort;
 
-    /**
-     * Returns true if a port is available, false otherwise.
-     * Availabilty of ports:
-     *    - If it's an output port, it's always available.
-     *    - If it's an input port, to be considered available,
-     *      it must NOT be connected via a wire to another port.
-     *
-     * @returns True or false.
-     */
-    readonly isAvailable: boolean;
-}
+export type DigitalPort = APIToDigital<Port> & BaseDigitalPort;

--- a/src/projects/digital/api/circuit/src/public/DigitalWire.ts
+++ b/src/projects/digital/api/circuit/src/public/DigitalWire.ts
@@ -3,6 +3,7 @@ import type {ReadonlyWire, Wire} from "shared/api/circuit/public";
 import type {APIToDigital} from "./DigitalCircuit";
 
 
-export interface ReadonlyDigitalWire extends APIToDigital<ReadonlyWire> {}
-type W = APIToDigital<Wire> & ReadonlyDigitalWire;
-export interface DigitalWire extends W {}
+interface BaseDigitalWire {}
+
+export type ReadonlyDigitalWire = APIToDigital<ReadonlyWire> & BaseDigitalWire;
+export type DigitalWire = APIToDigital<Wire> & BaseDigitalWire;

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
@@ -93,9 +93,8 @@ export class DigitalCircuitImpl extends CircuitImpl<DigitalTypes> implements Dig
             this.state.sim.loadICState(ic.metadata.id, initialSimState);
 
         const objs = super.loadSchema(schema, opts);
-
-        // this.state.simRunner.propagationTime = schema.propagationTime
         this.state.sim.loadState(schema.simState);
+        this.propagationTime = schema.propagationTime;
 
         return objs;
     }

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
@@ -1,6 +1,6 @@
 import {CircuitImpl, IntegratedCircuitImpl} from "shared/api/circuit/public/impl/Circuit";
 
-import {APIToDigital, DigitalCircuit, DigitalIntegratedCircuit, DigitalObjContainer} from "../DigitalCircuit";
+import {APIToDigital, DigitalCircuit, DigitalIntegratedCircuit, ReadonlyDigitalObjContainer} from "../DigitalCircuit";
 import {DigitalCircuitState, DigitalTypes} from "./DigitalCircuitState";
 import {DigitalSchema} from "digital/api/circuit/schema";
 import {DigitalComponent} from "../DigitalComponent";
@@ -80,7 +80,7 @@ export class DigitalCircuitImpl extends CircuitImpl<DigitalTypes> implements Dig
         return objs;
     }
 
-    public override toSchema(container?: DigitalObjContainer): DigitalSchema.DigitalCircuit {
+    public override toSchema(container?: ReadonlyDigitalObjContainer): DigitalSchema.DigitalCircuit {
         const ics = container?.ics ?? this.getICs();
 
         return {

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalCircuit.ts
@@ -1,12 +1,13 @@
 import {CircuitImpl, IntegratedCircuitImpl} from "shared/api/circuit/public/impl/Circuit";
 
-import {APIToDigital, DigitalCircuit, DigitalIntegratedCircuit, ReadonlyDigitalObjContainer} from "../DigitalCircuit";
+import {APIToDigital, DigitalCircuit, DigitalIntegratedCircuit, DigitalObjContainer, ReadonlyDigitalObjContainer} from "../DigitalCircuit";
 import {DigitalCircuitState, DigitalTypes} from "./DigitalCircuitState";
 import {DigitalSchema} from "digital/api/circuit/schema";
 import {DigitalComponent} from "../DigitalComponent";
 import {DigitalPort} from "../DigitalPort";
 import {DigitalWire} from "../DigitalWire";
 import {GUID, ICInfo} from "shared/api/circuit/public";
+import {ObjContainer} from "shared/api/circuit/public/ObjContainer";
 
 
 export class DigitalCircuitImpl extends CircuitImpl<DigitalTypes> implements DigitalCircuit {
@@ -43,9 +44,28 @@ export class DigitalCircuitImpl extends CircuitImpl<DigitalTypes> implements Dig
         return ic;
     }
 
+    public get simState(): DigitalSchema.DigitalSimState {
+        return this.state.sim.getSimState().toSchema();
+    }
+
     // TODO[model_refactor_api](leon) - revisit this
     public step() {
         this.state.sim.step();
+    }
+
+    public override import(
+        circuit: DigitalCircuit,
+        opts?: { refreshIds?: boolean, loadMetadata?: boolean }
+    ): DigitalObjContainer {
+        for (const ic of circuit.getICs())
+            this.state.sim.loadICState(ic.id, ic.initialSimState);
+
+        const objs = super.import(circuit, opts);
+
+        // this.state.simRunner.propagationTime = schema.propagationTime
+        this.state.sim.loadState(circuit.simState);
+
+        return objs;
     }
 
     public override loadSchema(

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalCircuitState.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalCircuitState.ts
@@ -1,8 +1,8 @@
 import {CircuitState, CircuitTypes} from "shared/api/circuit/public/impl/CircuitState";
 
-import {DigitalCircuit, DigitalICInfo, DigitalIntegratedCircuit, DigitalObjContainer} from "../DigitalCircuit";
+import {DigitalCircuit, DigitalICInfo, DigitalIntegratedCircuit, DigitalObjContainer, ReadonlyDigitalObjContainer} from "../DigitalCircuit";
 import {DigitalComponent, DigitalNode} from "../DigitalComponent";
-import {DigitalPort}                   from "../DigitalPort";
+import {DigitalPort, ReadonlyDigitalPort}                   from "../DigitalPort";
 import {DigitalWire}                   from "../DigitalWire";
 
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
@@ -14,10 +14,12 @@ export type DigitalTypes = CircuitTypes<
     DigitalComponent,
     DigitalWire,
     DigitalPort,
+    ReadonlyDigitalPort,
     DigitalNode,
     DigitalIntegratedCircuit,
     DigitalICInfo,
-    DigitalObjContainer
+    DigitalObjContainer,
+    ReadonlyDigitalObjContainer
 >;
 
 export interface DigitalCircuitState extends CircuitState<DigitalTypes> {

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalCircuitState.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalCircuitState.ts
@@ -1,9 +1,9 @@
 import {CircuitState, CircuitTypes} from "shared/api/circuit/public/impl/CircuitState";
 
 import {DigitalCircuit, DigitalICInfo, DigitalIntegratedCircuit, DigitalObjContainer, ReadonlyDigitalObjContainer} from "../DigitalCircuit";
-import {DigitalComponent, DigitalNode} from "../DigitalComponent";
+import {DigitalComponent, DigitalNode, ReadonlyDigitalComponent} from "../DigitalComponent";
 import {DigitalPort, ReadonlyDigitalPort}                   from "../DigitalPort";
-import {DigitalWire}                   from "../DigitalWire";
+import {DigitalWire, ReadonlyDigitalWire}                   from "../DigitalWire";
 
 import {DigitalSim} from "digital/api/circuit/internal/sim/DigitalSim";
 import {DigitalSimRunner} from "digital/api/circuit/internal/sim/DigitalSimRunner";
@@ -14,6 +14,8 @@ export type DigitalTypes = CircuitTypes<
     DigitalComponent,
     DigitalWire,
     DigitalPort,
+    ReadonlyDigitalComponent,
+    ReadonlyDigitalWire,
     ReadonlyDigitalPort,
     DigitalNode,
     DigitalIntegratedCircuit,

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalComponent.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalComponent.ts
@@ -12,8 +12,8 @@ import {DigitalCircuitState, DigitalTypes} from "./DigitalCircuitState";
 export class DigitalComponentImpl extends ComponentImpl<DigitalTypes> implements DigitalComponent {
     protected override readonly state: DigitalCircuitState;
 
-    public constructor(state: DigitalCircuitState, id: GUID) {
-        super(state, id);
+    public constructor(state: DigitalCircuitState, id: GUID, icId?: GUID) {
+        super(state, id, icId);
 
         this.state = state;
     }
@@ -26,6 +26,8 @@ export class DigitalComponentImpl extends ComponentImpl<DigitalTypes> implements
     }
 
     public setSimState(state: Signal[]): void {
+        if (this.icId)
+            throw new Error(`DigitalComponentImpl: Cannot set sim state for component with ID '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
         this.state.sim.setState(this.id, state);
     }
 }

--- a/src/projects/digital/api/circuit/src/public/impl/DigitalPort.ts
+++ b/src/projects/digital/api/circuit/src/public/impl/DigitalPort.ts
@@ -11,8 +11,8 @@ import {DigitalCircuitState, DigitalTypes} from "./DigitalCircuitState";
 export class DigitalPortImpl extends PortImpl<DigitalTypes> implements DigitalPort {
     protected override readonly state: DigitalCircuitState;
 
-    public constructor(state: DigitalCircuitState, id: GUID) {
-        super(state, id);
+    public constructor(state: DigitalCircuitState, id: GUID, icId?: GUID) {
+        super(state, id, icId);
 
         this.state = state;
     }
@@ -29,6 +29,8 @@ export class DigitalPortImpl extends PortImpl<DigitalTypes> implements DigitalPo
     }
 
     public get signal(): Signal {
+        if (this.icId)
+            throw new Error(`DigitalPortImpl: Signal cannot be accessed for ports inside an IC! Port ID: '${this.id}', IC ID: '${this.icId}'`);
         return this.state.sim.getSignal(this.id);
     }
 }

--- a/src/projects/digital/api/circuitdesigner/src/tools/ICPortTool.ts
+++ b/src/projects/digital/api/circuitdesigner/src/tools/ICPortTool.ts
@@ -44,7 +44,7 @@ export class ICPortTool extends ObservableImpl<ToolEvent> implements Tool {
     private findPin(pos: Vector, circuit: Circuit, viewport: Viewport): ICPin | undefined {
         const ic = this.getIC(circuit), icData = this.getICData(circuit);
 
-        const port = circuit.pickPortAt(viewport.camera.toWorldPos(pos));
+        const port = circuit.pickPortAt(viewport.toWorldPos(pos));
         if (!port || port.parent.id !== ic.id)
             return undefined;
 
@@ -89,7 +89,7 @@ export class ICPortTool extends ObservableImpl<ToolEvent> implements Tool {
         const ic = this.getIC(circuit), icData = this.getICData(circuit);
         const size = icData.display.size;
 
-        const worldMousePos = viewport.camera.toWorldPos(ev.input.mousePos);
+        const worldMousePos = viewport.toWorldPos(ev.input.mousePos);
 
         const p = GetNearestPointOnRect(new Rect(ic.pos, size, true), worldMousePos);
 

--- a/src/projects/digital/api/circuitdesigner/src/tools/ICResizeTool.ts
+++ b/src/projects/digital/api/circuitdesigner/src/tools/ICResizeTool.ts
@@ -54,7 +54,7 @@ export class ICResizeTool extends ObservableImpl<ToolEvent> implements Tool {
         const t1 = new Transform(ic.pos, 0, icData.display.size.add(EDGE_BUFFER));
         const t2 = new Transform(ic.pos, 0, icData.display.size.sub(EDGE_BUFFER));
 
-        const worldMousePos = viewport.camera.toWorldPos(pos);
+        const worldMousePos = viewport.toWorldPos(pos);
         if (!(RectContains(t1, worldMousePos) && !RectContains(t2, worldMousePos)))
             return "none";
 
@@ -103,7 +103,7 @@ export class ICResizeTool extends ObservableImpl<ToolEvent> implements Tool {
 
         const ic = this.getIC(circuit), icData = this.getICData(circuit);
 
-        const worldMousePos = viewport.camera.toWorldPos(ev.input.mousePos);
+        const worldMousePos = viewport.toWorldPos(ev.input.mousePos);
 
         const newSize = worldMousePos.sub(ic.pos).scale(2).abs();
 

--- a/src/projects/digital/api/circuitdesigner/src/tools/handlers/InteractionHandler.ts
+++ b/src/projects/digital/api/circuitdesigner/src/tools/handlers/InteractionHandler.ts
@@ -31,7 +31,7 @@ export const InteractionHandler: ToolHandler<DigitalTypes> = {
     canActivateWhenLocked: true,
 
     onEvent: (ev, { circuit, viewport }) => {
-        const pos = viewport.camera.toWorldPos(ev.input.mousePos);
+        const pos = viewport.toWorldPos(ev.input.mousePos);
 
         if (ev.type === "mousedown" && ev.button === LEFT_MOUSE_BUTTON) {
             const obj = circuit.pickObjAt(pos);

--- a/src/projects/digital/site/src/containers/ExprToCircuitPopup/generate.ts
+++ b/src/projects/digital/site/src/containers/ExprToCircuitPopup/generate.ts
@@ -1,4 +1,5 @@
 import {V} from "Vector";
+import {Camera} from "shared/api/circuit/public/Camera";
 import {DigitalCircuit} from "digital/api/circuit/public";
 import {ExpressionToCircuit} from "digital/site/utils/ExpressionParser"
 import {GenerateTokens} from "digital/site/utils/ExpressionParser/GenerateTokens"
@@ -7,7 +8,6 @@ import {OperatorFormat, OperatorFormatLabel} from "digital/site/utils/Expression
 import {FORMATS} from "digital/site/utils/ExpressionParser/Constants/Formats";
 import {Circuit, ICPin} from "shared/api/circuit/public";
 import {Err, Ok, Result} from "shared/api/circuit/utils/Result";
-import {Camera} from "shared/api/circuitdesigner/public/Camera";
 import {DigitalComponent} from "digital/api/circuit/public/DigitalComponent";
 import {CalculateICDisplay} from "digital/site/utils/CircuitUtils";
 

--- a/src/projects/digital/site/src/containers/ExprToCircuitPopup/index.tsx
+++ b/src/projects/digital/site/src/containers/ExprToCircuitPopup/index.tsx
@@ -1,5 +1,7 @@
 import {useState} from "react";
 
+import {Camera} from "shared/api/circuit/public/Camera";
+
 import {OperatorFormat, OperatorFormatLabel} from "digital/site/utils/ExpressionParser/Constants/DataStructures";
 import {FORMATS}                             from "digital/site/utils/ExpressionParser/Constants/Formats";
 
@@ -22,7 +24,6 @@ import {Generate,
         OutputTypes}    from "./generate";
 
 import "./index.scss";
-import {Camera} from "shared/api/circuitdesigner/public/Camera";
 
 
 type Props = {

--- a/src/projects/digital/site/src/containers/ICDesigner/index.tsx
+++ b/src/projects/digital/site/src/containers/ICDesigner/index.tsx
@@ -64,15 +64,12 @@ export const ICDesigner = ({ }: Props) => {
         const objs = mainDesigner.circuit.createContainer(objIds).withWiresAndPorts();
 
         const schema = mainDesigner.circuit.toSchema(objs);
-        // TODO[model_refactor_api] --
-        //  a weird state could exist when replacing switches with InputPorts
-        //  since it'll copy the state so if the switch is on, it'll turn off
-        //  when placed (maybe enforce them to be off?)
-        //  Also maybe enforce that there's no propagation happening in the circuit
-        //  you're trying to create?
-        for (const obj of schema.objects) {
-            if (obj.kind === "Switch" || obj.kind === "Button" || obj.kind === "Clock")
+        for (const obj of schema.comps) {
+            if (obj.kind === "Switch" || obj.kind === "Button" || obj.kind === "Clock") {
                 obj.kind = "InputPin";
+                // Remove sim state
+                delete schema.simState.states[obj.id];
+            }
             if (obj.kind === "LED")
                 obj.kind = "OutputPin";
             // Remove isSelected

--- a/src/projects/digital/site/src/containers/ICViewer/index.tsx
+++ b/src/projects/digital/site/src/containers/ICViewer/index.tsx
@@ -122,7 +122,7 @@ export const ICViewer = () => {
         if (!ic)
             throw new Error(`ICViewer: Failed to find ic with id ${icInstance.kind}!`);
         const schema = ic.toSchema();
-        for (const obj of schema.objects) {
+        for (const obj of schema.comps) {
             if (obj.kind === "InputPin")
                 obj.kind = "Switch";
             if (obj.kind === "OutputPin")
@@ -130,7 +130,9 @@ export const ICViewer = () => {
         }
         circuit.loadSchema({
             metadata: schema.metadata,
-            objects:  schema.objects,
+            comps:    schema.comps,
+            ports:    schema.ports,
+            wires:    schema.wires,
             ics:      mainDesigner.circuit.toSchema().ics,
             camera:   { x: 0, y: 0, zoom: 0.02 },
 

--- a/src/projects/digital/site/src/index.tsx
+++ b/src/projects/digital/site/src/index.tsx
@@ -187,7 +187,6 @@ async function Init(): Promise<void> {
                             return VersionMigrator(text).schema;
                         }
                     })();
-                    console.log(schema);
                     return DigitalProtoToCircuit(schema);
                 },
             });

--- a/src/projects/digital/site/src/index.tsx
+++ b/src/projects/digital/site/src/index.tsx
@@ -187,6 +187,7 @@ async function Init(): Promise<void> {
                             return VersionMigrator(text).schema;
                         }
                     })();
+                    console.log(schema);
                     return DigitalProtoToCircuit(schema);
                 },
             });

--- a/src/projects/digital/site/src/proto/DigitalCircuit.proto
+++ b/src/projects/digital/site/src/proto/DigitalCircuit.proto
@@ -16,7 +16,9 @@ message DigitalSimState {
 
     // Array of signals corresponding to the flat(circuit.components.map(allPorts))
     repeated Signal signals = 1;
+    // index of component in circuit.components : state of the component
     map<uint32, State> states = 2;
+    // index of component in circuit.components : state of the component
     map<uint32, DigitalSimState> icStates = 3;
 }
 

--- a/src/projects/digital/site/src/proto/DigitalCircuit.proto
+++ b/src/projects/digital/site/src/proto/DigitalCircuit.proto
@@ -14,10 +14,10 @@ message DigitalSimState {
         repeated Signal state = 1;
     }
 
-    // Array of signals corresponding to the circuit.ports
+    // Array of signals corresponding to the flat(circuit.components.map(allPorts))
     repeated Signal signals = 1;
-    map<string, State> states = 2;
-    map<string, DigitalSimState> icStates = 3;
+    map<uint32, State> states = 2;
+    map<uint32, DigitalSimState> icStates = 3;
 }
 
 message DigitalCircuit {

--- a/src/projects/digital/site/src/proto/DigitalCircuit.ts
+++ b/src/projects/digital/site/src/proto/DigitalCircuit.ts
@@ -15,7 +15,9 @@ export const protobufPackage = "";
 export interface DigitalSimState {
   /** Array of signals corresponding to the flat(circuit.components.map(allPorts)) */
   signals: DigitalSimState_Signal[];
+  /** index of component in circuit.components : state of the component */
   states: { [key: number]: DigitalSimState_State };
+  /** index of component in circuit.components : state of the component */
   icStates: { [key: number]: DigitalSimState };
 }
 

--- a/src/projects/digital/site/src/proto/DigitalCircuit.ts
+++ b/src/projects/digital/site/src/proto/DigitalCircuit.ts
@@ -13,10 +13,10 @@ export const protobufPackage = "";
 /** TODO[model_refactor_api] - .gitignore the generated .ts and generate it automatically via webpack? */
 
 export interface DigitalSimState {
-  /** Array of signals corresponding to the circuit.ports */
+  /** Array of signals corresponding to the flat(circuit.components.map(allPorts)) */
   signals: DigitalSimState_Signal[];
-  states: { [key: string]: DigitalSimState_State };
-  icStates: { [key: string]: DigitalSimState };
+  states: { [key: number]: DigitalSimState_State };
+  icStates: { [key: number]: DigitalSimState };
 }
 
 export enum DigitalSimState_Signal {
@@ -63,12 +63,12 @@ export interface DigitalSimState_State {
 }
 
 export interface DigitalSimState_StatesEntry {
-  key: string;
+  key: number;
   value: DigitalSimState_State | undefined;
 }
 
 export interface DigitalSimState_IcStatesEntry {
-  key: string;
+  key: number;
   value: DigitalSimState | undefined;
 }
 
@@ -162,14 +162,14 @@ export const DigitalSimState: MessageFns<DigitalSimState> = {
         ? object.signals.map((e: any) => digitalSimState_SignalFromJSON(e))
         : [],
       states: isObject(object.states)
-        ? Object.entries(object.states).reduce<{ [key: string]: DigitalSimState_State }>((acc, [key, value]) => {
-          acc[key] = DigitalSimState_State.fromJSON(value);
+        ? Object.entries(object.states).reduce<{ [key: number]: DigitalSimState_State }>((acc, [key, value]) => {
+          acc[globalThis.Number(key)] = DigitalSimState_State.fromJSON(value);
           return acc;
         }, {})
         : {},
       icStates: isObject(object.icStates)
-        ? Object.entries(object.icStates).reduce<{ [key: string]: DigitalSimState }>((acc, [key, value]) => {
-          acc[key] = DigitalSimState.fromJSON(value);
+        ? Object.entries(object.icStates).reduce<{ [key: number]: DigitalSimState }>((acc, [key, value]) => {
+          acc[globalThis.Number(key)] = DigitalSimState.fromJSON(value);
           return acc;
         }, {})
         : {},
@@ -208,19 +208,19 @@ export const DigitalSimState: MessageFns<DigitalSimState> = {
   fromPartial<I extends Exact<DeepPartial<DigitalSimState>, I>>(object: I): DigitalSimState {
     const message = createBaseDigitalSimState();
     message.signals = object.signals?.map((e) => e) || [];
-    message.states = Object.entries(object.states ?? {}).reduce<{ [key: string]: DigitalSimState_State }>(
+    message.states = Object.entries(object.states ?? {}).reduce<{ [key: number]: DigitalSimState_State }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
-          acc[key] = DigitalSimState_State.fromPartial(value);
+          acc[globalThis.Number(key)] = DigitalSimState_State.fromPartial(value);
         }
         return acc;
       },
       {},
     );
-    message.icStates = Object.entries(object.icStates ?? {}).reduce<{ [key: string]: DigitalSimState }>(
+    message.icStates = Object.entries(object.icStates ?? {}).reduce<{ [key: number]: DigitalSimState }>(
       (acc, [key, value]) => {
         if (value !== undefined) {
-          acc[key] = DigitalSimState.fromPartial(value);
+          acc[globalThis.Number(key)] = DigitalSimState.fromPartial(value);
         }
         return acc;
       },
@@ -305,13 +305,13 @@ export const DigitalSimState_State: MessageFns<DigitalSimState_State> = {
 };
 
 function createBaseDigitalSimState_StatesEntry(): DigitalSimState_StatesEntry {
-  return { key: "", value: undefined };
+  return { key: 0, value: undefined };
 }
 
 export const DigitalSimState_StatesEntry: MessageFns<DigitalSimState_StatesEntry> = {
   encode(message: DigitalSimState_StatesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.key !== "") {
-      writer.uint32(10).string(message.key);
+    if (message.key !== 0) {
+      writer.uint32(8).uint32(message.key);
     }
     if (message.value !== undefined) {
       DigitalSimState_State.encode(message.value, writer.uint32(18).fork()).join();
@@ -327,11 +327,11 @@ export const DigitalSimState_StatesEntry: MessageFns<DigitalSimState_StatesEntry
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1: {
-          if (tag !== 10) {
+          if (tag !== 8) {
             break;
           }
 
-          message.key = reader.string();
+          message.key = reader.uint32();
           continue;
         }
         case 2: {
@@ -353,15 +353,15 @@ export const DigitalSimState_StatesEntry: MessageFns<DigitalSimState_StatesEntry
 
   fromJSON(object: any): DigitalSimState_StatesEntry {
     return {
-      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      key: isSet(object.key) ? globalThis.Number(object.key) : 0,
       value: isSet(object.value) ? DigitalSimState_State.fromJSON(object.value) : undefined,
     };
   },
 
   toJSON(message: DigitalSimState_StatesEntry): unknown {
     const obj: any = {};
-    if (message.key !== "") {
-      obj.key = message.key;
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
       obj.value = DigitalSimState_State.toJSON(message.value);
@@ -374,7 +374,7 @@ export const DigitalSimState_StatesEntry: MessageFns<DigitalSimState_StatesEntry
   },
   fromPartial<I extends Exact<DeepPartial<DigitalSimState_StatesEntry>, I>>(object: I): DigitalSimState_StatesEntry {
     const message = createBaseDigitalSimState_StatesEntry();
-    message.key = object.key ?? "";
+    message.key = object.key ?? 0;
     message.value = (object.value !== undefined && object.value !== null)
       ? DigitalSimState_State.fromPartial(object.value)
       : undefined;
@@ -383,13 +383,13 @@ export const DigitalSimState_StatesEntry: MessageFns<DigitalSimState_StatesEntry
 };
 
 function createBaseDigitalSimState_IcStatesEntry(): DigitalSimState_IcStatesEntry {
-  return { key: "", value: undefined };
+  return { key: 0, value: undefined };
 }
 
 export const DigitalSimState_IcStatesEntry: MessageFns<DigitalSimState_IcStatesEntry> = {
   encode(message: DigitalSimState_IcStatesEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.key !== "") {
-      writer.uint32(10).string(message.key);
+    if (message.key !== 0) {
+      writer.uint32(8).uint32(message.key);
     }
     if (message.value !== undefined) {
       DigitalSimState.encode(message.value, writer.uint32(18).fork()).join();
@@ -405,11 +405,11 @@ export const DigitalSimState_IcStatesEntry: MessageFns<DigitalSimState_IcStatesE
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1: {
-          if (tag !== 10) {
+          if (tag !== 8) {
             break;
           }
 
-          message.key = reader.string();
+          message.key = reader.uint32();
           continue;
         }
         case 2: {
@@ -431,15 +431,15 @@ export const DigitalSimState_IcStatesEntry: MessageFns<DigitalSimState_IcStatesE
 
   fromJSON(object: any): DigitalSimState_IcStatesEntry {
     return {
-      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      key: isSet(object.key) ? globalThis.Number(object.key) : 0,
       value: isSet(object.value) ? DigitalSimState.fromJSON(object.value) : undefined,
     };
   },
 
   toJSON(message: DigitalSimState_IcStatesEntry): unknown {
     const obj: any = {};
-    if (message.key !== "") {
-      obj.key = message.key;
+    if (message.key !== 0) {
+      obj.key = Math.round(message.key);
     }
     if (message.value !== undefined) {
       obj.value = DigitalSimState.toJSON(message.value);
@@ -454,7 +454,7 @@ export const DigitalSimState_IcStatesEntry: MessageFns<DigitalSimState_IcStatesE
     object: I,
   ): DigitalSimState_IcStatesEntry {
     const message = createBaseDigitalSimState_IcStatesEntry();
-    message.key = object.key ?? "";
+    message.key = object.key ?? 0;
     message.value = (object.value !== undefined && object.value !== null)
       ? DigitalSimState.fromPartial(object.value)
       : undefined;

--- a/src/projects/digital/site/src/proto/bridge.ts
+++ b/src/projects/digital/site/src/proto/bridge.ts
@@ -1,22 +1,19 @@
 // This file has "bridge" functions from the internal rep (DigitalCircuit.Schema)
 // to the wire rep (DigitalCircuit.proto) and vice versa.
+import * as uuid from "uuid";
 
-import {MapObj} from "shared/api/circuit/utils/Functions";
 import {Schema} from "shared/api/circuit/schema";
 
 import {DigitalSchema} from "digital/api/circuit/schema";
 import {Signal} from "digital/api/circuit/schema/Signal";
 
-import {ProtoToSchema, SchemaToProto} from "shared/site/proto/bridge";
+import {CircuitToProto, ProtoToCircuit} from "shared/site/proto/bridge";
 
 import * as DigitalProtoSchema from "./DigitalCircuit";
+import {CreateCircuit, DigitalCircuit, ReadonlyDigitalCircuit} from "digital/api/circuit/public";
 
 
-function FindComponent(objs: Schema.Obj[], compId: Schema.GUID): Schema.Component | undefined {
-    return objs.find((o) => (o.baseKind === "Component" && o.id === compId)) as Schema.Component | undefined;
-}
-
-export function DigitalSchemaToProto(schema: DigitalSchema.DigitalCircuit): DigitalProtoSchema.DigitalCircuit {
+export function DigitalCircuitToProto(circuit: DigitalCircuit): DigitalProtoSchema.DigitalCircuit {
     function ConvertSignal(signal: Signal): DigitalProtoSchema.DigitalSimState_Signal {
         return (signal === Signal.On
             ? DigitalProtoSchema.DigitalSimState_Signal.On
@@ -27,27 +24,41 @@ export function DigitalSchemaToProto(schema: DigitalSchema.DigitalCircuit): Digi
             : DigitalProtoSchema.DigitalSimState_Signal.UNRECOGNIZED);
     }
 
-    function ConvertSimState(state: DigitalSchema.DigitalSimState, icId?: Schema.GUID): DigitalProtoSchema.DigitalSimState {
-        const objs = (icId ? schema.ics.find((ic) => (ic.metadata.id === icId))!.objects : schema.objects);
+    function ConvertSimState(circuit: ReadonlyDigitalCircuit, state: DigitalSchema.DigitalSimState, icId?: Schema.GUID): DigitalProtoSchema.DigitalSimState {
+        const comps = (icId ? circuit.getIC(icId)!.components : circuit.getComponents());
+        const ports = comps.flatMap((c) => c.allPorts);
         return {
-            signals: objs
-                .filter((o) => (o.baseKind === "Port"))
-                .map((p) => ConvertSignal(state.signals[p.id])),
-            states:   MapObj(state.states,   ([_id, state])  => ({ state: state.map(ConvertSignal) })),
-            icStates: MapObj(state.icStates, ([id, state]) => ConvertSimState(state, FindComponent(objs, id)?.icId)),
+            signals: ports.map((p) => ConvertSignal(state.signals[p.id] ?? Signal.Off)),
+            states:  Object.fromEntries(Object.entries(state.states)
+                .map(([id, state]) =>
+                    [comps.findIndex((c) => (c.id === id)), ({ state: state.map(ConvertSignal) })])),
+            icStates: Object.fromEntries(Object.entries(state.icStates)
+                .map(([id, state]) =>
+                    [comps.findIndex((c) => (c.id === id)), ConvertSimState(circuit, state, comps.find((c) => (c.id === id))!.kind)])),
         };
     }
 
-    return DigitalProtoSchema.DigitalCircuit.create({
-        circuit: SchemaToProto(schema),
+    const proto = DigitalProtoSchema.DigitalCircuit.create({
+        circuit: CircuitToProto(circuit),
 
-        propagationTime:    schema.propagationTime,
-        icInitialSimStates: schema.initialICSimStates.zip(schema.ics).map(([sim, ic]) => ConvertSimState(sim, ic.metadata.id)),
-        simState:           ConvertSimState(schema.simState),
+        propagationTime:    circuit.propagationTime,
+        icInitialSimStates: circuit.getICs().map((ic) => ConvertSimState(circuit, ic.initialSimState, ic.id)),
+        simState:           ConvertSimState(circuit, circuit.simState),
     });
+
+    console.log(proto);
+
+    return proto;
 }
 
-export function DigitalProtoToSchema(proto: DigitalProtoSchema.DigitalCircuit): DigitalSchema.DigitalCircuit {
+
+export function DigitalProtoToCircuit(proto: DigitalProtoSchema.DigitalCircuit): DigitalCircuit {
+    console.log(proto);
+
+    function ConvertId(id: Uint8Array): Schema.GUID {
+        return uuid.stringify(id);
+    }
+
     function ConvertSignal(signal: DigitalProtoSchema.DigitalSimState_Signal): Signal {
         return (signal === DigitalProtoSchema.DigitalSimState_Signal.On
             ? Signal.On
@@ -58,16 +69,15 @@ export function DigitalProtoToSchema(proto: DigitalProtoSchema.DigitalCircuit): 
             : Signal.Off);
     }
 
-    function ConvertSimState(state: DigitalProtoSchema.DigitalSimState, icId?: Schema.GUID): DigitalSchema.DigitalSimState {
-        const objs = (icId ? schema.ics.find((ic) => (ic.metadata.id === icId))!.objects : schema.objects);
+    function ConvertSimState(circuit: ReadonlyDigitalCircuit, state: DigitalProtoSchema.DigitalSimState, icId?: Schema.GUID): DigitalSchema.DigitalSimState {
+        const comps = (icId ? circuit.getIC(icId)!.components : circuit.getComponents());
+        const ports = comps.flatMap((c) => c.allPorts);
         return {
-            signals: Object.fromEntries(objs
-                .filter((o) => (o.baseKind === "Port"))
-                .zip(state.signals)
-                .map(([p, s]) => [p.id, ConvertSignal(s)])),
-            states:   MapObj(state.states,   ([_id, state])  => state.state.map(ConvertSignal)),
-            icStates: MapObj(state.icStates, ([id, state]) =>
-                ConvertSimState(state, FindComponent(objs, `${id}`)?.icId)),
+            signals: Object.fromEntries(ports.zip(state.signals).map(([p, s]) => [p.id, ConvertSignal(s)])),
+            states:  Object.fromEntries(Object.entries(state.states)
+                .map(([idx, state]) => [comps[parseInt(idx)].id, state.state.map(ConvertSignal)])),
+            icStates: Object.fromEntries(Object.entries(state.icStates)
+                .map(([idx, state]) => [comps[parseInt(idx)].id, ConvertSimState(circuit, state, comps[parseInt(idx)].kind)])),
         };
     }
 
@@ -76,13 +86,18 @@ export function DigitalProtoToSchema(proto: DigitalProtoSchema.DigitalCircuit): 
     if (!proto.simState)
         throw new Error(`DigitalProtoToSchema: Failed to find simState! ${proto}`);
 
-    const schema = ProtoToSchema(proto.circuit);
+    const [circuit, state] = CreateCircuit(ConvertId(proto.circuit!.metadata!.id));
 
-    return {
-        ...schema,
+    ProtoToCircuit(proto.circuit, circuit, (id) => CreateCircuit(id)[0]);
 
-        initialICSimStates: proto.icInitialSimStates.zip(schema.ics).map(([sim, ic]) => ConvertSimState(sim, ic.metadata.id)),
-        propagationTime:    proto.propagationTime,
-        simState:           ConvertSimState(proto.simState),
+    circuit.propagationTime = proto.propagationTime;
+
+    // Load simulation state
+    for (const [ic, initialSimState] of proto.circuit.ics.zip(proto.icInitialSimStates)) {
+        const id = ConvertId(ic.metadata!.metadata!.id);
+        state.sim.loadICState(id, ConvertSimState(circuit, initialSimState, id));
     }
+    state.sim.loadState(ConvertSimState(circuit, proto.simState));
+
+    return circuit;
 }

--- a/src/projects/digital/site/src/proto/bridge.ts
+++ b/src/projects/digital/site/src/proto/bridge.ts
@@ -53,8 +53,6 @@ export function DigitalCircuitToProto(circuit: DigitalCircuit): DigitalProtoSche
 
 
 export function DigitalProtoToCircuit(proto: DigitalProtoSchema.DigitalCircuit): DigitalCircuit {
-    console.log(proto);
-
     function ConvertId(id: Uint8Array): Schema.GUID {
         return uuid.stringify(id);
     }

--- a/src/projects/digital/site/src/proto/bridge.ts
+++ b/src/projects/digital/site/src/proto/bridge.ts
@@ -38,17 +38,13 @@ export function DigitalCircuitToProto(circuit: DigitalCircuit): DigitalProtoSche
         };
     }
 
-    const proto = DigitalProtoSchema.DigitalCircuit.create({
+    return DigitalProtoSchema.DigitalCircuit.create({
         circuit: CircuitToProto(circuit),
 
         propagationTime:    circuit.propagationTime,
         icInitialSimStates: circuit.getICs().map((ic) => ConvertSimState(circuit, ic.initialSimState, ic.id)),
         simState:           ConvertSimState(circuit, circuit.simState),
     });
-
-    console.log(proto);
-
-    return proto;
 }
 
 

--- a/src/projects/digital/site/src/utils/VersionMigrator/index.ts
+++ b/src/projects/digital/site/src/utils/VersionMigrator/index.ts
@@ -1,6 +1,6 @@
 import {DigitalProtoSchema} from "digital/site/proto";
 
-// import {IsV3_0, V3_0Migrator} from "./v3_0";
+import {IsV3_0, V3_0Migrator} from "./v3_0";
 
 
 interface VersionMigratorResult {
@@ -10,8 +10,8 @@ interface VersionMigratorResult {
 export function VersionMigrator(fileContents: string): VersionMigratorResult {
     const json = JSON.parse(fileContents);
 
-    // if (IsV3_0(json))
-    //     return V3_0Migrator(json);
+    if (IsV3_0(json))
+        return V3_0Migrator(json);
 
     return {
         schema:   json as DigitalProtoSchema.DigitalCircuit,

--- a/src/projects/digital/site/src/utils/VersionMigrator/index.ts
+++ b/src/projects/digital/site/src/utils/VersionMigrator/index.ts
@@ -1,20 +1,20 @@
-import {DigitalSchema} from "digital/api/circuit/schema";
+import {DigitalProtoSchema} from "digital/site/proto";
 
-import {IsV3_0, V3_0Migrator} from "./v3_0";
+// import {IsV3_0, V3_0Migrator} from "./v3_0";
 
 
 interface VersionMigratorResult {
-    schema: DigitalSchema.DigitalCircuit;
+    schema: DigitalProtoSchema.DigitalCircuit;
     warnings: string[];
 }
 export function VersionMigrator(fileContents: string): VersionMigratorResult {
     const json = JSON.parse(fileContents);
 
-    if (IsV3_0(json))
-        return V3_0Migrator(json);
+    // if (IsV3_0(json))
+    //     return V3_0Migrator(json);
 
     return {
-        schema:   json as DigitalSchema.DigitalCircuit,
+        schema:   json as DigitalProtoSchema.DigitalCircuit,
         warnings: [],
     };
 }

--- a/src/projects/digital/site/src/utils/VersionMigrator/v3_0/index.ts
+++ b/src/projects/digital/site/src/utils/VersionMigrator/v3_0/index.ts
@@ -13,6 +13,7 @@ import {Get} from "shared/api/circuit/utils/Reducers";
 import {MapObj} from "shared/api/circuit/utils/Functions";
 import * as V3_0Schema from "./Schema";
 import {Decompress, Entry, MakeEntry} from "./SerialeazyUtils";
+import {DigitalProtoSchema} from "digital/site/proto";
 
 
 enum Warnings {
@@ -427,7 +428,7 @@ export function V3_0Migrator(circuit: V3_0Schema.Circuit) {
 
             initialICSimStates,
             simState,
-        } satisfies DigitalSchema.DigitalCircuit,
+        } satisfies DigitalProtoSchema.DigitalCircuit,
         warnings: [...warnings].map((w) => ({
             [Warnings.ClockInIC]: IMPORT_IC_CLOCK_MESSAGE,
         }[w])),

--- a/src/projects/digital/site/tests/utils/VersionMigrator.test.ts
+++ b/src/projects/digital/site/tests/utils/VersionMigrator.test.ts
@@ -6,6 +6,8 @@ import {V} from "Vector";
 import {Signal}            from "digital/api/circuit/schema/Signal";
 import {CreateTestCircuit} from "digital/api/circuit/tests/helpers/CreateTestCircuit";
 
+import {DigitalProtoToCircuit} from "digital/site/proto/bridge";
+
 import {IMPORT_IC_CLOCK_MESSAGE} from "digital/site/utils/Constants";
 import {VersionMigrator}         from "digital/site/utils/VersionMigrator";
 
@@ -48,7 +50,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(switchCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(1);
             const sw = comps[0];
@@ -63,7 +65,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(orCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(4);
             expect(circuit.getWires()).toHaveLength(3);
@@ -90,7 +92,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(threeInputAndCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(5);
             expect(circuit.getWires()).toHaveLength(4);
@@ -115,7 +117,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(poweredOrCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             const led = comps.find((comp) => comp.kind === "LED")!;
             expect(led).toBeOn();
@@ -124,7 +126,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit(/* sim= */false);  // Disable sim since it will queue infinitely
             const { schema, warnings } = VersionMigrator(JSON.stringify(allInputsCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(8);
 
@@ -160,7 +162,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(ledCiruit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(1);
             const led = comps[0];
@@ -170,7 +172,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(segmentDisplayCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(6);
 
@@ -199,7 +201,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit(/* sim= */false);  // Disable sim since it will queue infinitely
             const { schema, warnings } = VersionMigrator(JSON.stringify(oscilloscopeCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(2);
 
@@ -224,7 +226,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(srFlipFlopCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(8);
             expect(circuit.getWires()).toHaveLength(7);
@@ -257,7 +259,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(jkFlipFlopCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(8);
             expect(circuit.getWires()).toHaveLength(7);
@@ -290,7 +292,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(dFlipFlopCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(7);
             expect(circuit.getWires()).toHaveLength(6);
@@ -320,7 +322,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(tFlipFlopCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(7);
             expect(circuit.getWires()).toHaveLength(6);
@@ -350,7 +352,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(dLatchCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(5);
             expect(circuit.getWires()).toHaveLength(4);
@@ -374,7 +376,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(srLatchCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(6);
             expect(circuit.getWires()).toHaveLength(5);
@@ -401,7 +403,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(multiplexerCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(10);
             expect(circuit.getWires()).toHaveLength(9);
@@ -441,7 +443,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(demultiplexerCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(10);
             expect(circuit.getWires()).toHaveLength(9);
@@ -482,7 +484,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(encoderDecoderCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(2);
 
@@ -500,7 +502,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(comparatorCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(10);
             expect(circuit.getWires()).toHaveLength(9);
@@ -545,7 +547,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(labelCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(1);
             const label = comps[0];
@@ -557,7 +559,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(nodesCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(5);
             expect(circuit.getWires()).toHaveLength(4);
@@ -566,7 +568,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(icDataOnlyCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(0);
             const ics = circuit.getICs();
@@ -581,7 +583,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(basicICCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(1);
             const icInstance = comps[0];
@@ -601,7 +603,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit, _, { Place, Connect, TurnOn }] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(nestedICCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(1);
             const icInstance = comps[0];
@@ -625,7 +627,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit, _, { }] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(zIndexCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(3);
             const bottom = comps.find(({ name }) => name === "Bottom")!;
@@ -648,7 +650,7 @@ describe("DigitalVersionMigrator", () => {
             expect(warnings).toBeDefined();
             expect(warnings).toHaveLength(1);
             expect(warnings).toContain(IMPORT_IC_CLOCK_MESSAGE);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
 
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(2);
@@ -672,7 +674,7 @@ describe("DigitalVersionMigrator", () => {
             expect(warnings).toBeDefined();
             expect(warnings).toHaveLength(1);
             expect(warnings).toContain(IMPORT_IC_CLOCK_MESSAGE);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
 
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(2);
@@ -694,7 +696,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit, _, { TurnOn, TurnOff }] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(threeInputICCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(5);
 
@@ -731,7 +733,7 @@ describe("DigitalVersionMigrator", () => {
             const [circuit, _, { TurnOn, TurnOff }] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(inputOrderICCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(5);
 
@@ -784,10 +786,10 @@ describe("DigitalVersionMigrator", () => {
             expect(out).toBeOff();
         });
         test("All Sides IC", () => {
-            const [circuit, _, { TurnOn, TurnOff }] = CreateTestCircuit();
+            const [circuit, _] = CreateTestCircuit();
             const { schema, warnings } = VersionMigrator(JSON.stringify(allSidesICCircuit));
             expect(warnings).toHaveLength(0);
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(5);
 
@@ -831,7 +833,7 @@ describe("DigitalVersionMigrator", () => {
             const { schema, warnings } = VersionMigrator(JSON.stringify(flipFlopInICCircuit));
             expect(warnings).toHaveLength(0);
 
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
 
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(1);
@@ -861,7 +863,7 @@ describe("DigitalVersionMigrator", () => {
             const { schema, warnings } = VersionMigrator(JSON.stringify(nestedICNotInDesignerCircuit));
             expect(warnings).toHaveLength(0);
 
-            circuit.loadSchema(schema);
+            circuit.import(DigitalProtoToCircuit(schema));
 
             const comps = circuit.getComponents();
             expect(comps).toHaveLength(1);

--- a/src/projects/digital/site/tsconfig.json
+++ b/src/projects/digital/site/tsconfig.json
@@ -22,6 +22,7 @@
     "include": ["../../shared/api/circuitdesigner/src/types"],
     "files": [
         "./src/index.tsx",
-        "./tests/containers/ExprToCircuitPopup.test.tsx"
+        "./tests/containers/ExprToCircuitPopup.test.tsx",
+        "./tests/utils/VersionMigrator.test.ts"
     ],
 }

--- a/src/projects/digital/site/tsconfig.json
+++ b/src/projects/digital/site/tsconfig.json
@@ -23,8 +23,6 @@
     "files": [
         "./src/index.tsx",
         "./tests/utils/VersionMigrator.test.ts",
-        "./tests/containers/ExprToCircuitPopup.test.tsx",
-        "./src/utils/DigitalVersionConflictResolver.ts",
-        "tests/utils/VersionMigrator.ts"
+        "./tests/containers/ExprToCircuitPopup.test.tsx"
     ],
 }

--- a/src/projects/digital/site/tsconfig.json
+++ b/src/projects/digital/site/tsconfig.json
@@ -22,7 +22,6 @@
     "include": ["../../shared/api/circuitdesigner/src/types"],
     "files": [
         "./src/index.tsx",
-        "./tests/utils/VersionMigrator.test.ts",
         "./tests/containers/ExprToCircuitPopup.test.tsx"
     ],
 }

--- a/src/projects/shared/api/circuit/src/internal/impl/CircuitDocument.ts
+++ b/src/projects/shared/api/circuit/src/internal/impl/CircuitDocument.ts
@@ -690,7 +690,7 @@ export class CircuitDocument extends ObservableImpl<CircuitDocEvent> implements 
                 .uponOk(() => {
                     // Copy-on-write
                     obj.props = { ...obj.props };
-                    if (op.newVal)
+                    if (op.newVal !== undefined)
                         obj.props[op.key] = op.newVal;
                     else
                         delete obj.props[op.key];

--- a/src/projects/shared/api/circuit/src/internal/impl/CircuitDocument.ts
+++ b/src/projects/shared/api/circuit/src/internal/impl/CircuitDocument.ts
@@ -710,7 +710,7 @@ export class CircuitDocument extends ObservableImpl<CircuitDocEvent> implements 
                 throw new Error(`Created IC ${op.ic.metadata.id} should not already exist!`);
 
             const storage = new CircuitStorage<Schema.IntegratedCircuitMetadata>(this.objInfo, op.ic.metadata);
-            storage.addObjs(op.ic.objects);
+            storage.addObjs([...op.ic.comps, ...op.ic.ports, ...op.ic.wires]);
             this.icStorage.set(op.ic.metadata.id, storage);
             this.objInfo.createIC(op.ic);
         }

--- a/src/projects/shared/api/circuit/src/internal/impl/CircuitInternal.ts
+++ b/src/projects/shared/api/circuit/src/internal/impl/CircuitInternal.ts
@@ -507,7 +507,9 @@ export class CircuitInternal extends ObservableImpl<InternalEvent> {
                     inverted: true,
                     ic:       {
                         metadata: ic.metadata,
-                        objects:  [...ic.getAllObjs()],
+                        comps:    [...ic.getAllObjs()].filter((o) => (o.baseKind === "Component")),
+                        wires:    [...ic.getAllObjs()].filter((o) => (o.baseKind === "Wire")),
+                        ports:    [...ic.getAllObjs()].filter((o) => (o.baseKind === "Port")),
                     },
                 }))
             .mapErr(AddErrE(`CircuitInternal.deleteIC: failed for ${id}`))

--- a/src/projects/shared/api/circuit/src/internal/impl/ObjInfo.ts
+++ b/src/projects/shared/api/circuit/src/internal/impl/ObjInfo.ts
@@ -120,7 +120,7 @@ export class BaseObjInfo<K extends Schema.Obj["baseKind"]> implements ObjInfo {
 
     public checkPropValue(key: string, value?: Schema.Prop): Result {
         if (!(key in this.props))
-            return ErrE(`BaseObjInfo: ${key} not a valid prop`);
+            return ErrE(`BaseObjInfo: ${key} not a valid prop, valid props: [${Object.keys(this.props).join(",")}]`);
         if (value && (this.props[key] !== typeof value))
             return ErrE(`BaseObjInfo: ${key} expected type ${this.props[key]}, got ${typeof value}`);
         return OkVoid();

--- a/src/projects/shared/api/circuit/src/public/BaseObject.ts
+++ b/src/projects/shared/api/circuit/src/public/BaseObject.ts
@@ -3,7 +3,7 @@ import {Rect} from "math/Rect";
 import {Prop} from "shared/api/circuit/schema";
 
 
-export interface ReadonlyBaseObject {
+interface BaseReadonlyBaseObject {
     readonly kind: string;
     readonly id: string;
     readonly bounds: Rect;
@@ -19,11 +19,9 @@ export interface ReadonlyBaseObject {
     getProps(): Readonly<Record<string, Prop>>;
 }
 
-export interface BaseObject extends ReadonlyBaseObject {
-    readonly kind: string;
-    readonly id: string;
-    readonly bounds: Rect;
+export type ReadonlyBaseObject = BaseReadonlyBaseObject;
 
+export type BaseObject = BaseReadonlyBaseObject & {
     name: string | undefined;
 
     isSelected: boolean;
@@ -32,9 +30,5 @@ export interface BaseObject extends ReadonlyBaseObject {
     select(): void;
     deselect(): void;
 
-    exists(): boolean;
-
     setProp(key: string, val: Prop): void;
-    getProp(key: string): Prop | undefined;
-    getProps(): Readonly<Record<string, Prop>>;
 }

--- a/src/projects/shared/api/circuit/src/public/Camera.ts
+++ b/src/projects/shared/api/circuit/src/public/Camera.ts
@@ -1,7 +1,6 @@
 import {Vector} from "Vector";
 import {Obj} from "shared/api/circuit/public";
 import {Observable} from "shared/api/circuit/utils/Observable";
-import {Matrix2x3} from "math/Matrix";
 import {Margin} from "math/Rect";
 
 
@@ -17,19 +16,14 @@ export type CameraEvent = {
 }
 
 export interface Camera extends Observable<CameraEvent> {
-    readonly matrix: Matrix2x3;
-
     cx: number;
     cy: number;
     pos: Vector;
 
     zoom: number;
 
-    translate(delta: Vector, space?: Vector.Spaces): void;
+    translate(delta: Vector): void;
     zoomTo(zoom: number, pos: Vector): void;
-
-    toWorldPos(screenPos: Vector): Vector;
-    toScreenPos(worldPos: Vector): Vector;
 
     zoomToFit(objs: Obj[], margin?: Margin, padRatio?: number): void;
 }

--- a/src/projects/shared/api/circuit/src/public/Circuit.ts
+++ b/src/projects/shared/api/circuit/src/public/Circuit.ts
@@ -52,7 +52,7 @@ interface BaseReadonlyCircuit<PortT, CompT, WireT, ICT, ObjCT, SelectionsT> {
     pickWireAt(pt: Vector): WireT | undefined;
     pickPortAt(pt: Vector): PortT | undefined;
 
-    pickObjectsWithin(bounds: Rect): Array<PortT | CompT | WireT>;
+    pickObjsWithin(bounds: Rect): ObjCT;
     pickComponentsWithin(bounds: Rect): CompT[];
     pickPortsWithin(bounds: Rect): PortT[];
 
@@ -61,7 +61,7 @@ interface BaseReadonlyCircuit<PortT, CompT, WireT, ICT, ObjCT, SelectionsT> {
     getWire(id: GUID): WireT | undefined;
     getPort(id: GUID): PortT | undefined;
 
-    getObjs(): ObjCT;  // TODO: Readonly
+    getObjs(): ObjCT;
     getComponents(): CompT[];
     getWires(): WireT[];
 
@@ -96,6 +96,8 @@ export type Circuit = BaseReadonlyCircuit<Port, Component, Wire, IntegratedCircu
 
     undo(): void;
     redo(): void;
+
+    import(circuit: Circuit, opts?: { refreshIds?: boolean, loadMetadata?: boolean }): ObjContainer;
 
     // TODO: Come up with a better name for this
     loadSchema(schema: Schema.Circuit, opts?: { refreshIds?: boolean, loadMetadata?: boolean }): Obj[];
@@ -135,5 +137,9 @@ export interface IntegratedCircuit {
     readonly thumbnail: string;
 
     readonly display: IntegratedCircuitDisplay;
+
+    readonly components: ReadonlyComponent[];
+    readonly wires: ReadonlyWire[];
+
     toSchema(): Schema.IntegratedCircuit;
 }

--- a/src/projects/shared/api/circuit/src/public/Circuit.ts
+++ b/src/projects/shared/api/circuit/src/public/Circuit.ts
@@ -14,6 +14,7 @@ import {Observable} from "../utils/Observable";
 import {ObjContainer, ReadonlyObjContainer} from "./ObjContainer";
 import {LogEntry} from "../internal/impl/CircuitLog";
 import {Rect} from "math/Rect";
+import {Camera} from "./Camera";
 
 
 // TODO[model_refactor](leon) - make this more user friendly
@@ -84,6 +85,7 @@ export type Circuit = BaseReadonlyCircuit<Port, Component, Wire, IntegratedCircu
     name: string;
     desc: string;
     thumbnail: string;
+    readonly camera: Camera;
 
     // Object manipulation
     placeComponentAt(kind: string, pt: Vector): Component;

--- a/src/projects/shared/api/circuit/src/public/Circuit.ts
+++ b/src/projects/shared/api/circuit/src/public/Circuit.ts
@@ -6,12 +6,12 @@ import {FastCircuitDiff} from "shared/api/circuit/internal/impl/FastCircuitDiff"
 
 import {Component, ReadonlyComponent}     from "./Component";
 import {ComponentInfo} from "./ComponentInfo";
-import {Obj, ReadonlyObj}           from "./Obj";
+import {Obj}           from "./Obj";
 import {Port, ReadonlyPort}          from "./Port";
 import {ReadonlyWire, Wire}          from "./Wire";
-import {Selections}    from "./Selections";
+import {ReadonlySelections, Selections}    from "./Selections";
 import {Observable} from "../utils/Observable";
-import {ObjContainer} from "./ObjContainer";
+import {ObjContainer, ReadonlyObjContainer} from "./ObjContainer";
 import {LogEntry} from "../internal/impl/CircuitLog";
 import {Rect} from "math/Rect";
 
@@ -21,33 +21,6 @@ export interface CircuitEvent {
     type: "change";
     diff: FastCircuitDiff;
 }
-
-export interface ReadonlyCircuit {
-    readonly id: GUID;
-    readonly name: string;
-    readonly desc: string;
-    readonly thumbnail: string;
-
-    // Queries
-    pickObjAt(pt: Vector): ReadonlyObj | undefined;
-    pickComponentAt(pt: Vector): ReadonlyComponent | undefined;
-    pickWireAt(pt: Vector): ReadonlyWire | undefined;
-    pickPortAt(pt: Vector): ReadonlyPort | undefined;
-
-    getObj(id: GUID): ReadonlyObj | undefined;
-    getComponent(id: GUID): ReadonlyComponent | undefined;
-    getWire(id: GUID): ReadonlyWire | undefined;
-    getPort(id: GUID): ReadonlyPort | undefined;
-
-    getObjs(): ReadonlyObj[];
-    getComponents(): ReadonlyComponent[];
-    getWires(): ReadonlyWire[];
-
-    getComponentInfo(kind: string): ComponentInfo | undefined;
-
-    toSchema(): Schema.Circuit;
-}
-
 export interface CircuitHistoryEvent {
     type: "change";
 }
@@ -57,44 +30,60 @@ export interface CircuitHistory extends Observable<CircuitHistoryEvent> {
 
     clear(): void;
 }
+export interface ICInfo {
+    circuit: ReadonlyCircuit;
+    display: ReadonlyIntegratedCircuitDisplay;
+}
 
-type C = Observable<CircuitEvent> & ReadonlyCircuit;
-export interface Circuit extends C {
+interface BaseReadonlyCircuit<PortT, CompT, WireT, ICT, ObjCT, SelectionsT> {
+    readonly id: GUID;
+    readonly name: string;
+    readonly desc: string;
+    readonly thumbnail: string;
+
+    readonly history: CircuitHistory;
+    readonly selections: SelectionsT;
+
+    createContainer(objs: GUID[]): ObjCT;
+
+    // Queries
+    pickObjAt(pt: Vector): PortT | CompT | WireT | undefined;
+    pickComponentAt(pt: Vector): CompT | undefined;
+    pickWireAt(pt: Vector): WireT | undefined;
+    pickPortAt(pt: Vector): PortT | undefined;
+
+    pickObjectsWithin(bounds: Rect): Array<PortT | CompT | WireT>;
+    pickComponentsWithin(bounds: Rect): CompT[];
+    pickPortsWithin(bounds: Rect): PortT[];
+
+    getObj(id: GUID): PortT | CompT | WireT | undefined;
+    getComponent(id: GUID): CompT | undefined;
+    getWire(id: GUID): WireT | undefined;
+    getPort(id: GUID): PortT | undefined;
+
+    getObjs(): ObjCT;  // TODO: Readonly
+    getComponents(): CompT[];
+    getWires(): WireT[];
+
+    getComponentInfo(kind: string): ComponentInfo | undefined;
+
+    getIC(id: GUID): ICT | undefined;
+    getICs(): ICT[];
+
+    toSchema(container?: ObjCT): Schema.Circuit;
+}
+
+export type ReadonlyCircuit = BaseReadonlyCircuit<ReadonlyPort, ReadonlyComponent, ReadonlyWire, IntegratedCircuit, ReadonlyObjContainer, ReadonlySelections> & Observable<CircuitEvent>;
+
+export type Circuit = BaseReadonlyCircuit<Port, Component, Wire, IntegratedCircuit, ObjContainer, Selections> & Observable<CircuitEvent> & {
     beginTransaction(options?: { batch?: boolean }): void;
     commitTransaction(clientData?: string): void;
     cancelTransaction(): void;
 
     // Metadata
-    readonly id: GUID;
     name: string;
     desc: string;
     thumbnail: string;
-
-    readonly selections: Selections;
-    readonly history: CircuitHistory;
-
-    // Queries
-    pickObjAt(pt: Vector): Obj | undefined;
-    pickComponentAt(pt: Vector): Component | undefined;
-    pickWireAt(pt: Vector): Wire | undefined;
-    pickPortAt(pt: Vector): Port | undefined;
-
-    pickObjectsWithin(bounds: Rect): Obj[];
-    pickComponentsWithin(bounds: Rect): Component[];
-    pickPortsWithin(bounds: Rect): Port[];
-
-    getObj(id: GUID): Obj | undefined;
-    getComponent(id: GUID): Component | undefined;
-    getWire(id: GUID): Wire | undefined;
-    getPort(id: GUID): Port | undefined;
-
-    getObjs(): Obj[];
-    getComponents(): Component[];
-    getWires(): Wire[];
-
-    getComponentInfo(kind: string): ComponentInfo | undefined;
-
-    createContainer(objs: GUID[]): ObjContainer;
 
     // Object manipulation
     placeComponentAt(kind: string, pt: Vector): Component;
@@ -104,17 +93,13 @@ export interface Circuit extends C {
     importICs(ics: IntegratedCircuit[]): void;
     createIC(info: ICInfo, id?: GUID): IntegratedCircuit;
     deleteIC(id: GUID): void;
-    getIC(id: GUID): IntegratedCircuit | undefined;
-    getICs(): IntegratedCircuit[];
 
     undo(): void;
     redo(): void;
 
     // TODO: Come up with a better name for this
     loadSchema(schema: Schema.Circuit, opts?: { refreshIds?: boolean, loadMetadata?: boolean }): Obj[];
-    toSchema(container?: ObjContainer): Schema.Circuit;
 }
-
 
 export interface ReadonlyICPin {
     readonly id: GUID;  // ID of corresponding PORT
@@ -125,11 +110,6 @@ export interface ReadonlyICPin {
     readonly pos: Vector;
     readonly dir: Vector;
 }
-export interface ReadonlyIntegratedCircuitDisplay {
-    readonly size: Vector;
-    readonly pins: ReadonlyICPin[];
-}
-
 export interface ICPin extends ReadonlyICPin {
     readonly id: GUID;  // ID of corresponding PORT
     readonly group: string;
@@ -137,15 +117,16 @@ export interface ICPin extends ReadonlyICPin {
     pos: Vector;
     dir: Vector;
 }
+
+export interface ReadonlyIntegratedCircuitDisplay {
+    readonly size: Vector;
+    readonly pins: ReadonlyICPin[];
+}
 export interface IntegratedCircuitDisplay extends ReadonlyIntegratedCircuitDisplay {
     size: Vector;
     readonly pins: ICPin[];
 }
 
-export interface ICInfo {
-    circuit: ReadonlyCircuit;
-    display: ReadonlyIntegratedCircuitDisplay;
-}
 export interface IntegratedCircuit {
     readonly id: GUID;
 

--- a/src/projects/shared/api/circuit/src/public/Component.ts
+++ b/src/projects/shared/api/circuit/src/public/Component.ts
@@ -1,16 +1,16 @@
-import {Vector} from "Vector";
+import type {Vector} from "Vector";
 
-import {BaseObject, ReadonlyBaseObject} from "./BaseObject";
-import {ComponentInfo} from "./ComponentInfo";
-import {Port, ReadonlyPort} from "./Port";
-import {Wire, ReadonlyWire} from "./Wire";
-import {Schema} from "../schema";
-import {PortConfig} from "../internal/impl/ObjInfo";
+import type {BaseObject, ReadonlyBaseObject} from "./BaseObject";
+import type {ComponentInfo} from "./ComponentInfo";
+import type {Port, ReadonlyPort} from "./Port";
+import type {ReadonlyWire, Wire} from "./Wire";
+import type {Schema} from "../schema";
+import type {PortConfig} from "../internal/impl/ObjInfo";
 
 export type {PortConfig} from "../internal/impl/ObjInfo";
 
 
-export interface ReadonlyComponent extends ReadonlyBaseObject {
+interface BaseReadonlyComponent<PortT, NodeT> {
     readonly baseKind: "Component";
     readonly info: ComponentInfo;
 
@@ -19,40 +19,26 @@ export interface ReadonlyComponent extends ReadonlyBaseObject {
     readonly pos: Vector;
     readonly angle: number;
 
-    isNode(): this is Node;
+    isNode(): this is NodeT;
 
-    readonly ports: Record<string, ReadonlyPort[]>;
-    readonly allPorts: ReadonlyPort[];
+    readonly ports: Record<string, PortT[]>;
+    readonly allPorts: PortT[];
 
     // Do we even want this in the API?
     // readonly connectedComponents: Component[];
 
-    firstAvailable(group: string): ReadonlyPort | undefined;
+    firstAvailable(group: string): PortT | undefined;
 
     toSchema(): Schema.Component;
 }
 
-export interface ReadonlyNode extends ReadonlyComponent {
-    readonly path: Array<ReadonlyNode | ReadonlyWire>;
-}
+export type ReadonlyComponent = ReadonlyBaseObject & BaseReadonlyComponent<ReadonlyPort, ReadonlyNode>;
 
-type C = BaseObject & ReadonlyComponent;
-export interface Component extends C {
-    readonly baseKind: "Component";
-    readonly info: ComponentInfo;
-
+export type Component = BaseObject & BaseReadonlyComponent<Port, Node> & {
     x: number;
     y: number;
     pos: Vector;
     angle: number;
-
-    isNode(): this is Node;
-
-    readonly ports: Record<string, Port[]>;
-    readonly allPorts: Port[];
-
-    // Do we even want this in the API?
-    // readonly connectedComponents: Component[];
 
     shift(): void;
 
@@ -60,13 +46,14 @@ export interface Component extends C {
     firstAvailable(group: string): Port | undefined;
 
     delete(): void;
-
-    toSchema(): Schema.Component;
 }
 
-type N = Component & ReadonlyNode;
-export interface Node extends N {
-    snip(): Wire;
 
-    readonly path: Array<Node | Wire>;
+interface BaseNode<NodeT, WireT> {
+    readonly path: Array<NodeT | WireT>;
+}
+
+export type ReadonlyNode = ReadonlyComponent & BaseNode<ReadonlyNode, ReadonlyWire>;
+export type Node = Component & BaseNode<Node, Wire> & {
+    snip(): Wire;
 }

--- a/src/projects/shared/api/circuit/src/public/Component.ts
+++ b/src/projects/shared/api/circuit/src/public/Component.ts
@@ -20,6 +20,7 @@ interface BaseReadonlyComponent<PortT, NodeT> {
     readonly angle: number;
 
     isNode(): this is NodeT;
+    isIC(): boolean;
 
     readonly ports: Record<string, PortT[]>;
     readonly allPorts: PortT[];

--- a/src/projects/shared/api/circuit/src/public/ObjContainer.ts
+++ b/src/projects/shared/api/circuit/src/public/ObjContainer.ts
@@ -1,14 +1,13 @@
 import {Vector} from "Vector";
 import {Rect}   from "math/Rect";
 
-import {Component}  from "./Component";
-import {Obj}        from "./Obj";
-import {Wire}       from "./Wire";
-import {Port}       from "./Port";
-import {IntegratedCircuit} from "./Circuit";
+import {Component, ReadonlyComponent} from "./Component";
+import {ReadonlyWire, Wire}           from "./Wire";
+import {Port, ReadonlyPort}           from "./Port";
+import {IntegratedCircuit}            from "./Circuit";
 
 
-export interface ObjContainer {
+interface BaseReadonlyObjContainer<PortT, CompT, WireT, ICT, ObjCT> {
     // Returns the bounding box of all the objects in the container.
     readonly bounds: Rect;
 
@@ -18,22 +17,26 @@ export interface ObjContainer {
     readonly length: number;
     readonly isEmpty: boolean;
 
-    readonly all: Obj[];
-    readonly components: Component[];
-    readonly wires: Wire[];
-    readonly ports: Port[];
+    readonly all: Array<PortT | CompT | WireT>;
+    readonly components: CompT[];
+    readonly wires: WireT[];
+    readonly ports: PortT[];
 
     // Returns only the ICs that are referenced by components in this container.
-    readonly ics: IntegratedCircuit[];
+    readonly ics: ICT[];
 
     // Returns a new ObjContainer with the wires that are connected between components in this container
     // and ports of components.
-    withWiresAndPorts(): ObjContainer;
+    withWiresAndPorts(): ObjCT;
 
+    forEach(f: (obj: PortT | CompT | WireT, i: number, arr: Array<PortT | CompT | WireT>) => void): void;
+    filter(f: (obj: PortT | CompT | WireT, i: number, arr: Array<PortT | CompT | WireT>) => boolean): Array<PortT | CompT | WireT>;
+    filter<O extends PortT | CompT | WireT>(f: (obj: PortT | CompT | WireT, i: number, arr: Array<PortT | CompT | WireT>) => obj is O): O[];
+    every(condition: (obj: PortT | CompT | WireT, i: number, arr: Array<PortT | CompT | WireT>) => boolean): boolean;
+}
+
+export type ReadonlyObjContainer = BaseReadonlyObjContainer<ReadonlyPort, ReadonlyComponent, ReadonlyWire, IntegratedCircuit, ReadonlyObjContainer>;
+
+export type ObjContainer = BaseReadonlyObjContainer<Port, Component, Wire, IntegratedCircuit, ObjContainer> & {
     shift(): void;
-
-    forEach(f: (obj: Obj, i: number, arr: Obj[]) => void): void;
-    filter(f: (obj: Obj, i: number, arr: Obj[]) => boolean): Obj[];
-    filter<O extends Obj>(f: (obj: Obj, i: number, arr: Obj[]) => obj is O): O[];
-    every(condition: (obj: Obj, i: number, arr: Obj[]) => boolean): boolean;
 }

--- a/src/projects/shared/api/circuit/src/public/Port.ts
+++ b/src/projects/shared/api/circuit/src/public/Port.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import {Vector} from "Vector";
+import type {Vector} from "Vector";
 
-import {BaseObject, ReadonlyBaseObject}      from "./BaseObject";
-import {Component, Node, ReadonlyComponent, ReadonlyNode} from "./Component";
-import {ReadonlyWire, Wire}            from "./Wire";
-import {Schema} from "../schema";
+import type {BaseObject, ReadonlyBaseObject}      from "./BaseObject";
+import type {Component, Node, ReadonlyComponent, ReadonlyNode} from "./Component";
+import type {ReadonlyWire, Wire}            from "./Wire";
+import type {Schema} from "../schema";
 
 
-export interface ReadonlyPort extends ReadonlyBaseObject {
+interface BaseReadonlyPort<PortT, CompT, NodeT, WireT> {
     readonly baseKind: "Port";
 
-    readonly parent: ReadonlyComponent;
+    readonly parent: CompT;
     readonly group: string;
     readonly index: number;
 
@@ -18,47 +18,24 @@ export interface ReadonlyPort extends ReadonlyBaseObject {
     readonly targetPos: Vector;
     readonly dir: Vector;
 
-    readonly connections: ReadonlyWire[];
+    readonly connections: WireT[];
     // TODO[model_refactor_api]: What about nodes? Should this be endpoint non-node components?
-    readonly connectedPorts: ReadonlyPort[];
+    readonly connectedPorts: PortT[];
     // TODO[model_refactor_api]: connectedComponents?
 
     // TODO[model_refactor_api](leon): Maybe make some Path API object? Could be 'walkable'
-    readonly path: Array<ReadonlyNode | ReadonlyWire>;
+    readonly path: Array<NodeT | WireT>;
 
     // "Availability" refers to the ability to have more connections added to this port.
     readonly isAvailable: boolean;
 
-    canConnectTo(port: Port): boolean;
+    canConnectTo(port: PortT): boolean;
 
     toSchema(): Schema.Port;
 }
 
-type P = BaseObject & ReadonlyPort;
-export interface Port extends P {
-    readonly baseKind: "Port";
+export type ReadonlyPort = ReadonlyBaseObject & BaseReadonlyPort<ReadonlyPort, ReadonlyComponent, ReadonlyNode, ReadonlyWire>;
 
-    readonly parent: Component;
-    readonly group: string;
-    readonly index: number;
-
-    readonly originPos: Vector;
-    readonly targetPos: Vector;
-    readonly dir: Vector;
-
-    readonly connections: Wire[];
-    // TODO[model_refactor_api]: What about nodes? Should this be endpoint non-node components?
-    readonly connectedPorts: Port[];
-    // TODO[model_refactor_api]: connectedComponents?
-
-    // TODO[model_refactor_api](leon): Maybe make some Path API object? Could be 'walkable'
-    readonly path: Array<Node | Wire>;
-
-    // "Availability" refers to the ability to have more connections added to this port.
-    readonly isAvailable: boolean;
-
-    canConnectTo(port: Port): boolean;
+export type Port = BaseObject & BaseReadonlyPort<Port, Component, Node, Wire> & {
     connectTo(other: Port): Wire | undefined;
-
-    toSchema(): Schema.Port;
 }

--- a/src/projects/shared/api/circuit/src/public/Selections.ts
+++ b/src/projects/shared/api/circuit/src/public/Selections.ts
@@ -1,6 +1,6 @@
 import {Observable} from "../utils/Observable";
 
-import {ObjContainer} from "./ObjContainer";
+import {ObjContainer, ReadonlyObjContainer} from "./ObjContainer";
 
 
 export type SelectionsEvent = {
@@ -8,6 +8,7 @@ export type SelectionsEvent = {
     newAmt: number;
 }
 
-export interface Selections extends ObjContainer, Observable<SelectionsEvent> {
+export type ReadonlySelections = ReadonlyObjContainer;
+export type Selections = ObjContainer & Observable<SelectionsEvent> & {
     clear(): void;
 }

--- a/src/projects/shared/api/circuit/src/public/Wire.ts
+++ b/src/projects/shared/api/circuit/src/public/Wire.ts
@@ -1,40 +1,29 @@
-import {Curve} from "math/Curve";
+import type {Curve} from "math/Curve";
 
-import {BaseObject, ReadonlyBaseObject} from "./BaseObject";
-import {Node, ReadonlyNode} from "./Component";
-import {Port, ReadonlyPort} from "./Port";
-import {Schema} from "../schema";
+import type {BaseObject, ReadonlyBaseObject} from "./BaseObject";
+import type {Node, ReadonlyNode} from "./Component";
+import type {Port, ReadonlyPort} from "./Port";
+import type {Schema} from "../schema";
 
 
-export interface ReadonlyWire extends ReadonlyBaseObject {
+interface BaseReadonlyWire<PortT, NodeT, WireT> {
     readonly baseKind: "Wire";
 
     readonly shape: Curve;
 
-    readonly p1: ReadonlyPort;
-    readonly p2: ReadonlyPort;
+    readonly p1: PortT;
+    readonly p2: PortT;
 
     // TODO[model_refactor_api](leon): Maybe make some Path API object? Could be 'walkable'
-    readonly path: Array<ReadonlyNode | ReadonlyWire>;
+    readonly path: Array<NodeT | WireT>;
 
     toSchema(): Schema.Wire;
 }
 
-type W = BaseObject & ReadonlyWire;
-export interface Wire extends W {
-    readonly baseKind: "Wire";
+export type ReadonlyWire = ReadonlyBaseObject & BaseReadonlyWire<ReadonlyPort, ReadonlyNode, ReadonlyWire>;
 
-    readonly shape: Curve;
-
-    readonly p1: Port;
-    readonly p2: Port;
-
-    // TODO[model_refactor_api](leon): Maybe make some Path API object? Could be 'walkable'
-    readonly path: Array<Node | Wire>;
-
+export type Wire = BaseObject & BaseReadonlyWire<Port, Node, Wire> & {
     split(): { node: Node, wire1: Wire, wire2: Wire };
 
     delete(): void;
-
-    toSchema(): Schema.Wire;
 }

--- a/src/projects/shared/api/circuit/src/public/impl/Camera.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Camera.ts
@@ -1,58 +1,28 @@
 import {V, Vector} from "Vector";
 import {Clamp}     from "math/MathUtils";
-import {Matrix2x3} from "math/Matrix";
 import {Margin}    from "math/Rect";
 
-import {DirtyVar}  from "shared/api/circuit/utils/DirtyVar";
 import {ObservableImpl} from "shared/api/circuit/utils/Observable";
-import {CircuitTypes} from "shared/api/circuit/public/impl/CircuitState";
+import {CircuitState, CircuitTypes} from "shared/api/circuit/public/impl/CircuitState";
 
 
 import {Camera, CameraEvent} from "../Camera";
-import {Viewport} from "../Viewport";
-import {CircuitDesignerState} from "./CircuitDesignerState";
 
 
 export const MIN_ZOOM = 1e-6;
 export const MAX_ZOOM = 200;
 
 export class CameraImpl<T extends CircuitTypes> extends ObservableImpl<CameraEvent> implements Camera {
-    protected readonly state: CircuitDesignerState<T>;
-    protected readonly view: Viewport;
+    protected readonly state: CircuitState<T>;
 
-    protected readonly mat: DirtyVar<Matrix2x3>;
-
-    public constructor(state: CircuitDesignerState<T>, view: Viewport) {
+    public constructor(state: CircuitState<T>) {
         super();
 
         this.state = state;
-        this.view = view;
-        this.mat = new DirtyVar<Matrix2x3>(() => {
-            const { x, y, zoom } = this.internal.getCamera();
-
-            const screenSize = view.canvasInfo?.screenSize ?? V(0, 0);
-            return new Matrix2x3(
-                V(x - screenSize.x/2 * zoom, y - screenSize.y/2 * -zoom),
-                0,
-                V(zoom, -zoom)
-            );
-        });
-
-        // Need to be careful with this kind of subscription model
-        // It could be a memory leak if Camera instances are created and disposed of
-        // since we can't know when to unsubscribe since we there are no destructors in JS
-        // So we should make sure the camera is only created once per-key and deleted if the IC or whatever is deleted
-        view.subscribe("onresize", (_) => {
-            this.mat.setDirty();
-        });
     }
 
     protected get internal() {
-        return this.state.circuitState.internal;
-    }
-
-    public get matrix(): Matrix2x3 {
-        return this.mat.get();
+        return this.state.internal;
     }
 
     public set cx(x: number) {
@@ -65,7 +35,6 @@ export class CameraImpl<T extends CircuitTypes> extends ObservableImpl<CameraEve
 
         this.internal.setCamera({ x });
         this.publish({ type: "change", dx, dy: 0, dz: 0 });
-        this.mat.setDirty();
     }
     public get cx(): number {
         return this.internal.getCamera().x;
@@ -80,7 +49,6 @@ export class CameraImpl<T extends CircuitTypes> extends ObservableImpl<CameraEve
 
         this.internal.setCamera({ y });
         this.publish({ type: "change", dx: 0, dy, dz: 0 });
-        this.mat.setDirty();
     }
     public get cy(): number {
         return this.internal.getCamera().y;
@@ -95,7 +63,6 @@ export class CameraImpl<T extends CircuitTypes> extends ObservableImpl<CameraEve
 
         this.internal.setCamera({ x, y });
         this.publish({ type: "change", dx, dy, dz: 0 });
-        this.mat.setDirty();
     }
     public get pos(): Vector {
         const camera = this.internal.getCamera();
@@ -103,7 +70,9 @@ export class CameraImpl<T extends CircuitTypes> extends ObservableImpl<CameraEve
         return V(camera.x, camera.y);
     }
 
-    public set zoom(zoom: number) {
+    public set zoom(z: number) {
+        const zoom = Clamp(z, MIN_ZOOM, MAX_ZOOM);
+
         const cam = this.internal.getCamera();
         const dz = (cam.zoom - zoom);
 
@@ -113,28 +82,18 @@ export class CameraImpl<T extends CircuitTypes> extends ObservableImpl<CameraEve
 
         this.internal.setCamera({ zoom });
         this.publish({ type: "change", dx: 0, dy: 0, dz: dz });
-        this.mat.setDirty();
     }
     public get zoom(): number {
         return this.internal.getCamera().zoom;
     }
 
-    public translate(delta: Vector, space: Vector.Spaces = "world"): void {
-        if (space === "screen")
-            return this.translate(V(delta.x * this.zoom, -delta.y * this.zoom));
+    public translate(delta: Vector): void {
         this.pos = this.pos.add(delta);
     }
-    public zoomTo(zoom: number, pos: Vector): void {
-        const pos0 = this.toWorldPos(pos);
-        this.zoom = Clamp(this.zoom * zoom, MIN_ZOOM, MAX_ZOOM);
-        this.translate(this.toScreenPos(pos0).sub(pos), "screen");
-    }
 
-    public toWorldPos(screenPos: Vector): Vector {
-        return this.mat.get().mul(screenPos);
-    }
-    public toScreenPos(worldPos: Vector): Vector {
-        return this.mat.get().inverse().mul(worldPos);
+    public zoomTo(dz: number, pos: Vector): void {
+        this.zoom *= dz;
+        this.translate(pos.sub(this.pos).scale(1 - dz));
     }
 
     public zoomToFit(_objs: T["Obj[]"], _margin?: Margin, _padRatio?: number): void {

--- a/src/projects/shared/api/circuit/src/public/impl/Circuit.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Circuit.ts
@@ -169,9 +169,8 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
             return this.getPort(id);
         return undefined;
     }
-    public getObjs(): T["Obj[]"] {
-        return [...this.internal.getObjs()]
-            .map((id) => this.getObj(id)!);
+    public getObjs(): T["ObjContainerT"] {
+        return new ObjContainerImpl<T>(this.state, new Set(this.internal.getObjs()));
     }
     public getComponents(): T["Component[]"] {
         return [...this.internal.getComps()]
@@ -279,7 +278,7 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
         this.internal.beginTransaction();
         this.internal.createIC({
             metadata,
-            objects: info.circuit.getObjs().map((o) => o.toSchema()),
+            objects: info.circuit.getObjs().all.map((o) => o.toSchema()),
         }).unwrap();
         this.internal.commitTransaction();
 
@@ -334,9 +333,9 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
 
         return objs.map((id) => this.getObj(id)!);
     }
-    public toSchema(container?: T["ObjContainerT"]): Schema.Circuit {
+    public toSchema(container?: T["ReadonlyObjContainerT"]): Schema.Circuit {
         const ics = container?.ics ?? this.getICs();
-        const objs = container?.all ?? this.getObjs();
+        const objs = container?.all ?? this.getObjs().all;
 
         return {
             metadata: this.internal.getMetadata(),

--- a/src/projects/shared/api/circuit/src/public/impl/Circuit.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Circuit.ts
@@ -17,6 +17,8 @@ import {LogEntry} from "../../internal/impl/CircuitLog";
 import {Component, ReadonlyComponent} from "../Component";
 import {ReadonlyWire, Wire} from "../Wire";
 import {Port, ReadonlyPort} from "../Port";
+import {Camera} from "../Camera";
+import {CameraImpl} from "./Camera";
 
 
 export type RemoveICCallback = (id: GUID) => void;
@@ -50,6 +52,8 @@ export class HistoryImpl extends ObservableImpl<CircuitHistoryEvent> implements 
 export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitEvent> implements Circuit {
     protected readonly state: CircuitState<T>;
 
+    public readonly camera: Camera;
+
     public readonly selections: SelectionsImpl<T>;
     public readonly history: CircuitHistory;
 
@@ -60,6 +64,8 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
 
         this.selections = new SelectionsImpl<T>(state);
         this.history = new HistoryImpl(state.internal);
+
+        this.camera = new CameraImpl(state);
 
         // This ordering is important, because it means that all previous circuit subscription calls will happen
         // before any public/outside subscriptions. (i.e. selections are updated before circuit subscribers are called).
@@ -317,7 +323,7 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
         this.internal.redo().unwrap();
     }
 
-    public import(circuit: T["Circuit"], opts?: { refreshIds?: boolean; loadMetadata?: boolean; }): T["ObjContainerT"] {
+    public import(circuit: T["Circuit"], opts?: { refreshIds?: boolean, loadMetadata?: boolean }): T["ObjContainerT"] {
         const refreshIds = opts?.refreshIds ?? false,
               loadMetadata = opts?.loadMetadata ?? false;
 
@@ -331,8 +337,7 @@ export class CircuitImpl<T extends CircuitTypes> extends ObservableImpl<CircuitE
                 desc:  circuit.desc,
                 thumb: circuit.thumbnail,
             });
-            // TODODODODOD
-            // this.internal.setCamera(schema.camera);
+            this.internal.setCamera({ x: circuit.camera.cx, y: circuit.camera.cy, zoom: circuit.camera.zoom });
         }
 
         function ConvertComp(c: ReadonlyComponent): Schema.Component {

--- a/src/projects/shared/api/circuit/src/public/impl/CircuitState.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/CircuitState.ts
@@ -1,10 +1,10 @@
-import {CircuitInternal}   from "shared/api/circuit/internal";
+import {CircuitInternal, GUID}   from "shared/api/circuit/internal";
 import {CircuitAssembler}  from "shared/api/circuit/internal/assembly/CircuitAssembler";
 import {RenderOptions}     from "shared/api/circuit/internal/assembly/RenderOptions";
 
-import {Component, Node}   from "../Component";
+import {Component, Node, ReadonlyComponent}   from "../Component";
 import {Port, ReadonlyPort}              from "../Port";
-import {Wire}              from "../Wire";
+import {ReadonlyWire, Wire}              from "../Wire";
 import {Circuit, ICInfo, IntegratedCircuit} from "../Circuit";
 import {ObjContainer, ReadonlyObjContainer} from "../ObjContainer";
 
@@ -12,13 +12,20 @@ import {ObjContainer, ReadonlyObjContainer} from "../ObjContainer";
 // Utility interface to hold utility types for the templated Circuit API.
 export type CircuitTypes<
     CircuitT extends Circuit = Circuit,
+
     ComponentT extends Component = Component,
     WireT extends Wire = Wire,
     PortT extends Port = Port,
+
+    RComponentT extends ReadonlyComponent = ReadonlyComponent,
+    RWireT extends ReadonlyWire = ReadonlyWire,
     RPortT extends ReadonlyPort = ReadonlyPort,
+
     NodeT extends Node = Node,
+
     ICT extends IntegratedCircuit = IntegratedCircuit,
     ICInfoT extends ICInfo = ICInfo,
+
     ObjContainerT extends ObjContainer = ObjContainer,
     RObjContainerT extends ReadonlyObjContainer = ReadonlyObjContainer,
 > = {
@@ -26,9 +33,23 @@ export type CircuitTypes<
 
     "Component": ComponentT;
     "Wire": WireT;
-    "ReadonlyPort": RPortT;
     "Port": PortT;
     "Obj": ComponentT | WireT | PortT;
+
+    "ReadonlyComponent": RComponentT;
+    "ReadonlyWire": RWireT;
+    "ReadonlyPort": RPortT;
+    "ReadonlyObj": RComponentT | RWireT | RPortT;
+
+    "Component[]": ComponentT[];
+    "Wire[]": WireT[];
+    "Port[]": PortT[];
+    "Obj[]": Array<ComponentT | WireT | PortT>;
+
+    "ReadonlyComponent[]": RComponentT[];
+    "ReadonlyWire[]": RWireT[];
+    "ReadonlyPort[]": RPortT[];
+    "ReadonlyObj[]": Array<RComponentT | RWireT | RPortT>;
 
     "IC": ICT;
 
@@ -36,11 +57,6 @@ export type CircuitTypes<
 
     "Node": NodeT;
     "Path": Array<NodeT | WireT>;
-
-    "Component[]": ComponentT[];
-    "Wire[]": WireT[];
-    "Port[]": PortT[];
-    "Obj[]": Array<ComponentT | WireT | PortT>;
     "IC[]": ICT[];
 
     "ICInfo": ICInfoT;
@@ -56,9 +72,9 @@ export interface CircuitState<T extends CircuitTypes> {
     // -> find options that can be extracted and put in separately that relate to rendering rather than assembly
     renderOptions: RenderOptions;
 
-    constructComponent(id: string): T["Component"];
-    constructWire(id: string): T["Wire"];
-    constructPort(id: string): T["Port"];
+    constructComponent(id: string, icId?: GUID): T["Component"];
+    constructWire(id: string, icId?: GUID): T["Wire"];
+    constructPort(id: string, icId?: GUID): T["Port"];
     constructIC(id: string): T["IC"];
     constructComponentInfo(kind: string): T["ComponentInfo"];
 }

--- a/src/projects/shared/api/circuit/src/public/impl/CircuitState.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/CircuitState.ts
@@ -1,12 +1,12 @@
-import {CircuitInternal, GUID}   from "shared/api/circuit/internal";
+import {CircuitInternal}   from "shared/api/circuit/internal";
 import {CircuitAssembler}  from "shared/api/circuit/internal/assembly/CircuitAssembler";
 import {RenderOptions}     from "shared/api/circuit/internal/assembly/RenderOptions";
 
 import {Component, Node}   from "../Component";
-import {Port}              from "../Port";
+import {Port, ReadonlyPort}              from "../Port";
 import {Wire}              from "../Wire";
 import {Circuit, ICInfo, IntegratedCircuit} from "../Circuit";
-import {ObjContainer} from "../ObjContainer";
+import {ObjContainer, ReadonlyObjContainer} from "../ObjContainer";
 
 
 // Utility interface to hold utility types for the templated Circuit API.
@@ -15,15 +15,18 @@ export type CircuitTypes<
     ComponentT extends Component = Component,
     WireT extends Wire = Wire,
     PortT extends Port = Port,
+    RPortT extends ReadonlyPort = ReadonlyPort,
     NodeT extends Node = Node,
     ICT extends IntegratedCircuit = IntegratedCircuit,
     ICInfoT extends ICInfo = ICInfo,
     ObjContainerT extends ObjContainer = ObjContainer,
+    RObjContainerT extends ReadonlyObjContainer = ReadonlyObjContainer,
 > = {
     "Circuit": CircuitT;
 
     "Component": ComponentT;
     "Wire": WireT;
+    "ReadonlyPort": RPortT;
     "Port": PortT;
     "Obj": ComponentT | WireT | PortT;
 
@@ -42,6 +45,7 @@ export type CircuitTypes<
 
     "ICInfo": ICInfoT;
     "ObjContainerT": ObjContainerT;
+    "ReadonlyObjContainerT": RObjContainerT;
 }
 
 export interface CircuitState<T extends CircuitTypes> {

--- a/src/projects/shared/api/circuit/src/public/impl/Component.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Component.ts
@@ -14,13 +14,14 @@ import {CircuitState, CircuitTypes} from "./CircuitState";
 export class ComponentImpl<T extends CircuitTypes> extends BaseObjectImpl<T> implements Component {
     public readonly baseKind = "Component";
 
-    public constructor(state: CircuitState<T>, id: GUID) {
-        super(state, id);
+    public constructor(state: CircuitState<T>, id: GUID, icId?: GUID) {
+        super(state, id, icId);
     }
 
     protected getComponent() {
-        return this.state.internal.getCompByID(this.id)
-            .mapErr(AddErrE(`API Component: Attempted to get component with ID '${this.id}' that doesn't exist!`))
+        return this.getCircuitInfo()
+            .getCompByID(this.id)
+            .mapErr(AddErrE(`ComponentImpl: Attempted to get component with ID '${this.id}' that doesn't exist!`))
             .unwrap();
     }
 
@@ -37,18 +38,24 @@ export class ComponentImpl<T extends CircuitTypes> extends BaseObjectImpl<T> imp
     }
 
     public set x(val: number) {
+        if (this.icId)
+            throw new Error(`ComponentImpl: Cannot set 'x' for component with ID '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
         this.state.internal.setPropFor<Schema.Component, "x">(this.id, "x", val);
     }
     public get x(): number {
         return (this.getComponent().props.x ?? 0);
     }
     public set y(val: number) {
+        if (this.icId)
+            throw new Error(`ComponentImpl: Cannot set 'y' for component with ID '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
         this.state.internal.setPropFor(this.id, "y", val);
     }
     public get y(): number {
         return (this.getComponent().props.y ?? 0);
     }
     public set pos(val: Vector) {
+        if (this.icId)
+            throw new Error(`ComponentImpl: Cannot set position for component with ID '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
         this.state.internal.beginTransaction();
         this.state.internal.setPropFor<Schema.Component, "x">(this.id, "x", val.x).unwrap();
         this.state.internal.setPropFor<Schema.Component, "y">(this.id, "y", val.y).unwrap();
@@ -59,6 +66,8 @@ export class ComponentImpl<T extends CircuitTypes> extends BaseObjectImpl<T> imp
         return V((obj.props.x ?? 0), (obj.props.y ?? 0));
     }
     public set angle(val: number) {
+        if (this.icId)
+            throw new Error(`ComponentImpl: Cannot set 'angle' for component with ID '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
         this.state.internal.setPropFor<Schema.Component, "angle">(this.id, "angle", val);
     }
     public get angle(): number {
@@ -66,17 +75,22 @@ export class ComponentImpl<T extends CircuitTypes> extends BaseObjectImpl<T> imp
     }
 
     public isNode(): this is T["Node"] {
-        return this.state.internal.getComponentAndInfoById(this.id)
+        return this.getCircuitInfo()
+            .getComponentAndInfoByID(this.id)
             .map(([_, info]) => info.isNode)
+            .mapErr(AddErrE(`ComponentImpl: Attempted to get component with ID '${this.id}' that doesn't exist!`))
             .unwrap();
+    }
+    public isIC(): boolean {
+        return this.state.internal.hasIC(this.kind);
     }
 
     public get ports(): Record<string, T["Port[]"]> {
         return FromConcatenatedEntries(this.allPorts.map((p) => [p.group, p]));
     }
     public get allPorts(): T["Port[]"] {
-        return [...this.state.internal.getPortsForComponent(this.id).unwrap()]
-            .map((id) => this.state.constructPort(id));
+        return [...this.getCircuitInfo().getPortsForComponent(this.id).unwrap()]
+            .map((id) => this.state.constructPort(id, this.icId));
     }
 
     // get connectedComponents(): T["Component[]"] {
@@ -88,6 +102,9 @@ export class ComponentImpl<T extends CircuitTypes> extends BaseObjectImpl<T> imp
     }
 
     public setPortConfig(cfg: PortConfig): boolean {
+        if (this.icId)
+            throw new Error(`ComponentImpl: Cannot set port config for component with ID '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
+
         // TODO[model_refactor](leon) revisit this and decide on a functionality
         const curConfig = this.state.internal.getPortConfig(this.id).unwrap();
 
@@ -105,18 +122,20 @@ export class ComponentImpl<T extends CircuitTypes> extends BaseObjectImpl<T> imp
         return true;
     }
     public firstAvailable(group: string): T["Port"] | undefined {
-        const ports = this.state.internal.getPortsByGroup(this.id).unwrap();
+        const ports = this.getCircuitInfo().getPortsByGroup(this.id).unwrap();
         if (!(group in ports))
             return undefined;
 
         for (const portId of ports[group]) {
-            const port = this.state.constructPort(portId);
+            const port = this.state.constructPort(portId, this.icId);
             if (port.isAvailable)
                 return port;
         }
         return undefined;
     }
     public delete(): void {
+        if (this.icId)
+            throw new Error(`ComponentImpl: Cannot delete component with ID '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
         this.state.internal.beginTransaction();
         this.state.internal.removePortsFor(this.id).unwrap();
         this.state.internal.deleteComponent(this.id).unwrap();

--- a/src/projects/shared/api/circuit/src/public/impl/ObjContainer.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/ObjContainer.ts
@@ -13,7 +13,7 @@ import "shared/api/circuit/utils/Array";
 export class ObjContainerImpl<T extends CircuitTypes> implements ObjContainer {
     protected readonly state: CircuitState<T>;
 
-    protected objs: Set<GUID>;
+    protected readonly objs: Set<GUID>;
 
     protected componentIds?: Set<GUID>;
     protected wireIds?: Set<GUID>;

--- a/src/projects/shared/api/circuit/src/public/impl/Port.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Port.ts
@@ -65,15 +65,15 @@ export abstract class PortImpl<T extends CircuitTypes> extends BaseObjectImpl<T>
 
         return parentInfo.isPortAvailable(p, curConnections);
     }
-    public canConnectTo(other: T["Port"]): boolean {
+    public canConnectTo(other: T["ReadonlyPort"] | T["Port"]): boolean {
         const p1 = this.getPort();
-        const [_, p1Info] = this.state.internal.getComponentAndInfoById(p1.parent).unwrap();
+        const [_c1, p1Info] = this.state.internal.getComponentAndInfoById(p1.parent).unwrap();
         const p1Connections = this.state.internal.getPortsForPort(p1.id)
             .map((ids) => [...ids].map((id) => this.state.internal.getPortByID(id).unwrap()))
             .unwrap();
 
         const p2 = this.state.internal.getPortByID(other.id).unwrap();
-        const [__, p2Info] = this.state.internal.getComponentAndInfoById(p2.parent).unwrap();
+        const [_c2, p2Info] = this.state.internal.getComponentAndInfoById(p2.parent).unwrap();
         const p2Connections = this.state.internal.getPortsForPort(p2.id)
             .map((ids) => [...ids].map((id) => this.state.internal.getPortByID(id).unwrap()))
             .unwrap();

--- a/src/projects/shared/api/circuit/src/public/impl/Port.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Port.ts
@@ -13,20 +13,21 @@ import {CircuitState, CircuitTypes} from "./CircuitState";
 export abstract class PortImpl<T extends CircuitTypes> extends BaseObjectImpl<T> implements Port {
     public readonly baseKind = "Port";
 
-    public constructor(state: CircuitState<T>, id: GUID) {
-        super(state, id);
+    public constructor(state: CircuitState<T>, id: GUID, icId?: GUID) {
+        super(state, id, icId);
     }
 
     protected getPort() {
-        return this.state.internal.getPortByID(this.id)
-            .mapErr(AddErrE(`API Port: Attempted to get port with ID '${this.id}' that doesn't exist!`))
+        return this.getCircuitInfo()
+            .getPortByID(this.id)
+            .mapErr(AddErrE(`PortImpl: Attempted to get port with ID '${this.id}' that doesn't exist!`))
             .unwrap();
     }
 
     protected abstract getWireKind(p1: GUID, p2: GUID): string;
 
     public get parent(): T["Component"] {
-        return this.state.constructComponent(this.getPort().parent);
+        return this.state.constructComponent(this.getPort().parent, this.icId);
     }
     public get group(): string {
         return this.getPort().group;
@@ -36,17 +37,23 @@ export abstract class PortImpl<T extends CircuitTypes> extends BaseObjectImpl<T>
     }
 
     public get originPos(): Vector {
+        if (this.icId)
+            throw new Error(`PortImpl: Origin Pos cannot be accessed for ports inside an IC! Port ID: '${this.id}', IC ID: '${this.icId}'`);
         return this.state.assembler.getPortPos(this.id).unwrap().origin;
     }
     public get targetPos(): Vector {
+        if (this.icId)
+            throw new Error(`PortImpl: Target Pos cannot be accessed for ports inside an IC! Port ID: '${this.id}', IC ID: '${this.icId}'`);
         return this.state.assembler.getPortPos(this.id).unwrap().target;
     }
     public get dir(): Vector {
+        if (this.icId)
+            throw new Error(`PortImpl: Direction cannot be accessed for ports inside an IC! Port ID: '${this.id}', IC ID: '${this.icId}'`);
         return this.targetPos.sub(this.originPos).normalize();
     }
 
     public get connections(): T["Wire[]"] {
-        return [...this.state.internal.getWiresForPort(this.id).unwrap()]
+        return [...this.getCircuitInfo().getWiresForPort(this.id).unwrap()]
             .map((id) => this.state.constructWire(id));
     }
     public get connectedPorts(): T["Port[]"] {
@@ -59,23 +66,23 @@ export abstract class PortImpl<T extends CircuitTypes> extends BaseObjectImpl<T>
 
     public get isAvailable(): boolean {
         const p = this.getPort();
-        const curConnections = [...this.state.internal.getPortsForPort(this.id).unwrap()]
-            .map((id) => this.state.internal.getPortByID(id).unwrap());
-        const [_, parentInfo] = this.state.internal.getComponentAndInfoById(p.parent).unwrap();
+        const curConnections = [...this.getCircuitInfo().getPortsForPort(this.id).unwrap()]
+            .map((id) => this.getCircuitInfo().getPortByID(id).unwrap());
+        const [_, parentInfo] = this.getCircuitInfo().getComponentAndInfoByID(p.parent).unwrap();
 
         return parentInfo.isPortAvailable(p, curConnections);
     }
     public canConnectTo(other: T["ReadonlyPort"] | T["Port"]): boolean {
         const p1 = this.getPort();
-        const [_c1, p1Info] = this.state.internal.getComponentAndInfoById(p1.parent).unwrap();
-        const p1Connections = this.state.internal.getPortsForPort(p1.id)
-            .map((ids) => [...ids].map((id) => this.state.internal.getPortByID(id).unwrap()))
+        const [_c1, p1Info] = this.getCircuitInfo().getComponentAndInfoByID(p1.parent).unwrap();
+        const p1Connections = this.getCircuitInfo().getPortsForPort(p1.id)
+            .map((ids) => [...ids].map((id) => this.getCircuitInfo().getPortByID(id).unwrap()))
             .unwrap();
 
-        const p2 = this.state.internal.getPortByID(other.id).unwrap();
-        const [_c2, p2Info] = this.state.internal.getComponentAndInfoById(p2.parent).unwrap();
-        const p2Connections = this.state.internal.getPortsForPort(p2.id)
-            .map((ids) => [...ids].map((id) => this.state.internal.getPortByID(id).unwrap()))
+        const p2 = this.getCircuitInfo().getPortByID(other.id).unwrap();
+        const [_c2, p2Info] = this.getCircuitInfo().getComponentAndInfoByID(p2.parent).unwrap();
+        const p2Connections = this.getCircuitInfo().getPortsForPort(p2.id)
+            .map((ids) => [...ids].map((id) => this.getCircuitInfo().getPortByID(id).unwrap()))
             .unwrap();
 
         return p1Info.checkPortConnectivity(p1, p2, p1Connections)
@@ -83,6 +90,9 @@ export abstract class PortImpl<T extends CircuitTypes> extends BaseObjectImpl<T>
     }
 
     public connectTo(other: T["Port"]): T["Wire"] | undefined {
+        if (this.icId)
+            throw new Error(`PortImpl: Cannot create connections for port '${this.id}' in IC ${this.icId}! IC objects are immutable!`);
+
         this.state.internal.beginTransaction();
 
         const id = this.state.internal.connectWire(

--- a/src/projects/shared/api/circuit/src/public/impl/Selections.ts
+++ b/src/projects/shared/api/circuit/src/public/impl/Selections.ts
@@ -8,7 +8,6 @@ import {CircuitState, CircuitTypes} from "./CircuitState";
 import {ObjContainerImpl} from "./ObjContainer";
 
 import "shared/api/circuit/utils/Array";
-import {ObjContainer} from "../ObjContainer";
 
 
 export class SelectionsImpl<T extends CircuitTypes> extends ObservableImpl<SelectionsEvent> implements Selections {

--- a/src/projects/shared/api/circuit/src/schema/Circuit.ts
+++ b/src/projects/shared/api/circuit/src/schema/Circuit.ts
@@ -1,7 +1,10 @@
 import {Camera}          from "./Camera";
 import {CircuitMetadata} from "./CircuitMetadata";
+import {Component} from "./Component";
 import {GUID}      from "./GUID";
 import {Obj}             from "./Obj";
+import {Port} from "./Port";
+import {Wire} from "./Wire";
 
 
 export interface IntegratedCircuitPin {
@@ -24,7 +27,10 @@ export interface IntegratedCircuitMetadata extends CircuitMetadata {
 
 export interface IntegratedCircuit {
     metadata: IntegratedCircuitMetadata;
-    objects: Obj[];
+
+    comps: Component[];
+    wires: Wire[];
+    ports: Port[];
 }
 
 export interface Circuit {
@@ -33,5 +39,7 @@ export interface Circuit {
     camera: Camera;
 
     ics: IntegratedCircuit[];
-    objects: Obj[];
+    comps: Component[];
+    wires: Wire[];
+    ports: Port[];
 }

--- a/src/projects/shared/api/circuit/tsconfig.json
+++ b/src/projects/shared/api/circuit/tsconfig.json
@@ -9,5 +9,5 @@
             "tests/helpers/*":      ["./tests/helpers/*"],
         },
     },
-    "include": ["."],
+    "include": ["."],, "../circuitdesigner/src/public/impl/Camera.ts"
 }

--- a/src/projects/shared/api/circuit/tsconfig.json
+++ b/src/projects/shared/api/circuit/tsconfig.json
@@ -9,5 +9,5 @@
             "tests/helpers/*":      ["./tests/helpers/*"],
         },
     },
-    "include": ["."],, "../circuitdesigner/src/public/impl/Camera.ts"
+    "include": ["."],
 }

--- a/src/projects/shared/api/circuitdesigner/src/public/Viewport.ts
+++ b/src/projects/shared/api/circuitdesigner/src/public/Viewport.ts
@@ -5,11 +5,12 @@ import {MultiObservable} from "shared/api/circuit/utils/Observable";
 import {Prim}            from "shared/api/circuit/internal/assembly/Prim";
 import {RenderOptions}   from "shared/api/circuit/internal/assembly/RenderOptions";
 
-import {Camera} from "./Camera";
+import {Camera} from "../../../circuit/src/public/Camera";
 import {Cursor} from "../input/Cursor";
 import {DebugOptions} from "./impl/DebugOptions";
 import {InputAdapter} from "../input/InputAdapter";
 import {CleanupFunc} from "shared/api/circuit/utils/types";
+import {Obj} from "shared/api/circuit/public";
 
 
 // Re-export prim types
@@ -63,4 +64,7 @@ export interface Viewport extends MultiObservable<ViewportEvents> {
     setRenderOptions(options: Partial<Pick<RenderOptions, "showGrid">>): void;
 
     resize(w: number, h: number): void;
+
+    toWorldPos(screenPos: Vector): Vector;
+    toScreenPos(worldPos: Vector): Vector;
 }

--- a/src/projects/shared/api/circuitdesigner/src/tools/DefaultTool.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/DefaultTool.ts
@@ -22,7 +22,7 @@ export class DefaultTool<T extends CircuitTypes = CircuitTypes> {
         if (ev.type === "mousedown") {
             // Find object if we pressed on one
             designer.curPressedObj = designer.circuit.pickObjAt(
-                designer.viewport.camera.toWorldPos(ev.input.mousePos));
+                designer.viewport.toWorldPos(ev.input.mousePos));
         } else if (ev.type === "mouseup") {
             designer.curPressedObj = undefined;
         }

--- a/src/projects/shared/api/circuitdesigner/src/tools/PanTool.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/PanTool.ts
@@ -50,7 +50,7 @@ export class PanTool extends ObservableImpl<ToolEvent> implements Tool {
     public onEvent(ev: InputAdapterEvent, { viewport }: CircuitDesigner): void {
         if (ev.type === "mousedrag") {
             const { x: dx, y: dy } = ev.input.deltaMousePos;
-            viewport.camera.translate(V(-dx, -dy), "screen");
+            viewport.camera.translate(V(-dx, dy).scale(viewport.camera.zoom));
             return;
         }
 
@@ -65,7 +65,7 @@ export class PanTool extends ObservableImpl<ToolEvent> implements Tool {
             // Screen gets moved different amounts depending on if shift key is held
             const factor = (ev.input.isShiftKeyDown ? ARROW_PAN_DISTANCE_SMALL : ARROW_PAN_DISTANCE_NORMAL);
 
-            viewport.camera.translate(V(dx, dy).scale(factor), "world");
+            viewport.camera.translate(V(dx, dy).scale(factor));
         }
     }
 }

--- a/src/projects/shared/api/circuitdesigner/src/tools/RotateTool.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/RotateTool.ts
@@ -46,7 +46,7 @@ export class RotateTool extends ObservableImpl<ToolEvent> implements Tool {
     }
 
     private isOnCircle(pos: Vector, circuit: Circuit, viewport: Viewport): boolean {
-        const worldPos = viewport.camera.toWorldPos(pos);
+        const worldPos = viewport.toWorldPos(pos);
         const d = worldPos.sub(circuit.selections.midpoint).len2();
 
         return (ROTATION_CIRCLE_R1 <= d && d <= ROTATION_CIRCLE_R2);
@@ -76,7 +76,9 @@ export class RotateTool extends ObservableImpl<ToolEvent> implements Tool {
         return (ev.type === "mouseup");
     }
 
-    public onActivate(ev: InputAdapterEvent, { circuit, viewport: { camera, canvasInfo } }: CircuitDesigner): void {
+    public onActivate(ev: InputAdapterEvent, { circuit, viewport }: CircuitDesigner): void {
+        const { camera, canvasInfo } = viewport;
+
         this.components = circuit.selections.components;
 
         camera.publish({ type: "dragStart" });
@@ -86,7 +88,7 @@ export class RotateTool extends ObservableImpl<ToolEvent> implements Tool {
         this.initialPositions = this.components.map((c) => c.pos);
         this.curAngles = this.components.map((c) => c.angle);
         this.curAroundAngle = 0;
-        this.startAngle = camera.toWorldPos(ev.input.mouseDownPos).sub(circuit.selections.midpoint).angle();
+        this.startAngle = viewport.toWorldPos(ev.input.mouseDownPos).sub(circuit.selections.midpoint).angle();
         this.prevAngle = this.startAngle;
 
         // Set cursor
@@ -102,14 +104,14 @@ export class RotateTool extends ObservableImpl<ToolEvent> implements Tool {
         camera.publish({ type: "dragEnd" });
     }
 
-    public onEvent(ev: InputAdapterEvent, { viewport: { camera } }: CircuitDesigner): void {
+    public onEvent(ev: InputAdapterEvent, { viewport }: CircuitDesigner): void {
         if (ev.type === "mousedrag") {
             // Get whether z is presesed for independent rotation
             const isIndependent = ev.input.keysDown.has("z");
 
             const midpoint = this.initialMidpoint;
 
-            const dAngle = camera.toWorldPos(ev.input.mousePos).sub(midpoint).angle() - this.prevAngle;
+            const dAngle = viewport.toWorldPos(ev.input.mousePos).sub(midpoint).angle() - this.prevAngle;
 
             // Calculate new and snapped angles
             const newAngles = this.curAngles.map((a) => (a + dAngle));

--- a/src/projects/shared/api/circuitdesigner/src/tools/SelectionBoxTool.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/SelectionBoxTool.ts
@@ -33,8 +33,8 @@ export class SelectionBoxTool extends ObservableImpl<ToolEvent> implements Tool 
 
     public onActivate(ev: InputAdapterEvent, { viewport }: CircuitDesigner): void {
         this.rect = Rect.FromPoints(
-            viewport.camera.toWorldPos(ev.input.mouseDownPos),
-            viewport.camera.toWorldPos(ev.input.mousePos),
+            viewport.toWorldPos(ev.input.mouseDownPos),
+            viewport.toWorldPos(ev.input.mousePos),
         );
     }
 
@@ -72,8 +72,8 @@ export class SelectionBoxTool extends ObservableImpl<ToolEvent> implements Tool 
     public onEvent(ev: InputAdapterEvent, { viewport }: CircuitDesigner): void {
         if (ev.type === "mousedrag") {
             this.rect = Rect.FromPoints(
-                viewport.camera.toWorldPos(ev.input.mouseDownPos),
-                viewport.camera.toWorldPos(ev.input.mousePos),
+                viewport.toWorldPos(ev.input.mouseDownPos),
+                viewport.toWorldPos(ev.input.mousePos),
             );
 
             this.publish({ type: "statechange" });

--- a/src/projects/shared/api/circuitdesigner/src/tools/TranslateTool.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/TranslateTool.ts
@@ -23,7 +23,7 @@ export class TranslateTool extends ObservableImpl<ToolEvent> implements Tool {
     }
 
     public indicateCouldActivate(ev: InputAdapterEvent, { circuit, viewport }: CircuitDesigner): Cursor | undefined {
-        if (circuit.pickObjAt(viewport.camera.toWorldPos(ev.input.mousePos))?.baseKind === "Component")
+        if (circuit.pickObjAt(viewport.toWorldPos(ev.input.mousePos))?.baseKind === "Component")
             return "pointer";
     }
     public shouldActivate(ev: InputAdapterEvent, { curPressedObj }: CircuitDesigner): boolean {
@@ -69,8 +69,8 @@ export class TranslateTool extends ObservableImpl<ToolEvent> implements Tool {
             const snapToGrid = ev.input.isShiftKeyDown;
             const snapToConnections = !ev.input.isShiftKeyDown;
 
-            const dPos = viewport.camera.toWorldPos(ev.input.mousePos)
-                .sub(viewport.camera.toWorldPos(ev.input.mouseDownPos));
+            const dPos = viewport.toWorldPos(ev.input.mousePos)
+                .sub(viewport.toWorldPos(ev.input.mouseDownPos));
 
             // Translate all selected components
             circuit.beginTransaction({ batch: true });

--- a/src/projects/shared/api/circuitdesigner/src/tools/WiringTool.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/WiringTool.ts
@@ -71,7 +71,7 @@ export class WiringTool extends ObservableImpl<ToolEvent> implements Tool {
     }
 
     public indicateCouldActivate(ev: InputAdapterEvent, { circuit, viewport }: CircuitDesigner): Cursor | undefined {
-        if (this.findPort(viewport.camera.toWorldPos(ev.input.mousePos), circuit) !== undefined)
+        if (this.findPort(viewport.toWorldPos(ev.input.mousePos), circuit) !== undefined)
             return "pointer";
     }
     public shouldActivate(ev: InputAdapterEvent, { circuit, viewport, curPressedObj }: CircuitDesigner): boolean {
@@ -82,7 +82,7 @@ export class WiringTool extends ObservableImpl<ToolEvent> implements Tool {
                 (ev.type === "click")
             )
             && (curPressedObj?.baseKind === "Port" ||
-                this.findPort(viewport.camera.toWorldPos(ev.input.mousePos), circuit) !== undefined)
+                this.findPort(viewport.toWorldPos(ev.input.mousePos), circuit) !== undefined)
         );
     }
     public shouldDeactivate(ev: InputAdapterEvent): boolean {
@@ -96,7 +96,7 @@ export class WiringTool extends ObservableImpl<ToolEvent> implements Tool {
     }
 
     public onActivate(ev: InputAdapterEvent, { circuit, curPressedObj, viewport }: CircuitDesigner): void {
-        const targetPos = viewport.camera.toWorldPos(ev.input.mousePos);
+        const targetPos = viewport.toWorldPos(ev.input.mousePos);
         this.curPort = curPressedObj?.baseKind === "Port"
             ? curPressedObj
             : this.findPort(targetPos, circuit);
@@ -109,7 +109,7 @@ export class WiringTool extends ObservableImpl<ToolEvent> implements Tool {
     }
 
     public onDeactivate(ev: InputAdapterEvent, { circuit, viewport }: CircuitDesigner): void {
-        const port2 = this.findPort(viewport.camera.toWorldPos(ev.input.mousePos), circuit, this.curPort);
+        const port2 = this.findPort(viewport.toWorldPos(ev.input.mousePos), circuit, this.curPort);
         if (port2 && this.curPort!.canConnectTo(port2)) // Connect the ports if we found a second port
             this.curPort!.connectTo(port2);
 
@@ -119,7 +119,7 @@ export class WiringTool extends ObservableImpl<ToolEvent> implements Tool {
 
     public onEvent(ev: InputAdapterEvent, { viewport }: CircuitDesigner): void {
         if (ev.type === "mousemove") {
-            this.curTarget = viewport.camera.toWorldPos(ev.input.mousePos);
+            this.curTarget = viewport.toWorldPos(ev.input.mousePos);
 
             this.publish({ type: "statechange" });
         }

--- a/src/projects/shared/api/circuitdesigner/src/tools/WiringTool.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/WiringTool.ts
@@ -51,8 +51,7 @@ export class WiringTool extends ObservableImpl<ToolEvent> implements Tool {
 
         // Otherwise, gather all ports that are within the wireable
         //  bounds (and can be wired), and find the closest one
-        const allPorts = circuit.getObjs()
-            .filter((obj) => (obj.baseKind === "Port"));
+        const allPorts = circuit.getObjs().ports;
         const validPorts = allPorts
             // Make sure port is wireable
             .filter((port) => port.isAvailable)

--- a/src/projects/shared/api/circuitdesigner/src/tools/handlers/FitToScreenHandler.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/handlers/FitToScreenHandler.ts
@@ -12,7 +12,7 @@ export function FitToScreen(circuit: Circuit, camera: Camera, margin: Margin): v
     camera.zoomToFit(
         // Fit selections if there are any, otherwise fit entire circuit
         (circuit.selections.isEmpty
-            ? circuit.getObjs()
+            ? circuit.getObjs().all
             : circuit.selections.all),
         margin,
         FIT_PADDING_RATIO

--- a/src/projects/shared/api/circuitdesigner/src/tools/handlers/FitToScreenHandler.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/handlers/FitToScreenHandler.ts
@@ -3,13 +3,13 @@ import {Margin} from "math/Rect";
 import {Circuit} from "shared/api/circuit/public";
 
 import {ToolHandler, ToolHandlerResponse} from "./ToolHandler";
-import {Camera} from "shared/api/circuitdesigner/public/Camera";
+import {Viewport} from "shared/api/circuitdesigner/public/Viewport";
 
 
 const FIT_PADDING_RATIO = 1.2;
 
-export function FitToScreen(circuit: Circuit, camera: Camera, margin: Margin): void {
-    camera.zoomToFit(
+export function FitToScreen(circuit: Circuit, viewport: Viewport, margin: Margin): void {
+    viewport.camera.zoomToFit(
         // Fit selections if there are any, otherwise fit entire circuit
         (circuit.selections.isEmpty
             ? circuit.getObjs().all
@@ -25,7 +25,7 @@ export const FitToScreenHandler: ToolHandler = {
         if (!(ev.type === "keyup" && ev.key === "f"))
             return ToolHandlerResponse.PASS;
 
-        FitToScreen(circuit, viewport.camera, viewport.margin);
+        FitToScreen(circuit, viewport, viewport.margin);
 
         // This should be the only handler to execute
         return ToolHandlerResponse.HALT;

--- a/src/projects/shared/api/circuitdesigner/src/tools/handlers/SelectPathHandler.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/handlers/SelectPathHandler.ts
@@ -32,13 +32,13 @@ export function GetComponentPath(c: Component): Component[] {
 }
 
 export const SelectPathHandler: ToolHandler = {
-    onEvent: (ev, { circuit, viewport: { camera } }) => {
+    onEvent: (ev, { circuit, viewport }) => {
         // Activate on double LMB click
         if (!(ev.type === "dblclick" && ev.button === LEFT_MOUSE_BUTTON))
             return ToolHandlerResponse.PASS;
 
         // Make sure we double clicked on something
-        const obj = circuit.pickObjAt(camera.toWorldPos(ev.input.mousePos));
+        const obj = circuit.pickObjAt(viewport.toWorldPos(ev.input.mousePos));
         if (!obj)
             return ToolHandlerResponse.PASS;
 

--- a/src/projects/shared/api/circuitdesigner/src/tools/handlers/SelectionHandler.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/handlers/SelectionHandler.ts
@@ -9,7 +9,7 @@ export const SelectionHandler: ToolHandler = {
 
         const deselectAll = (!ev.input.isShiftKeyDown && circuit.selections.length > 0);
 
-        const obj = circuit.pickObjAt(viewport.camera.toWorldPos(ev.input.mousePos));
+        const obj = circuit.pickObjAt(viewport.toWorldPos(ev.input.mousePos));
         if (!obj) {
             // Clear selections if not holding shift
             if (deselectAll) {

--- a/src/projects/shared/api/circuitdesigner/src/tools/handlers/ZoomHandler.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/handlers/ZoomHandler.ts
@@ -8,7 +8,7 @@ export const ZoomHandler: ToolHandler = {
         if (ev.type !== "zoom")
             return ToolHandlerResponse.PASS;
 
-        viewport.camera.zoomTo(ev.factor, ev.pos);
+        viewport.camera.zoomTo(ev.factor, viewport.toWorldPos(ev.pos));
 
         // This should be the only handler to handle the zoom event
         return ToolHandlerResponse.HALT;

--- a/src/projects/shared/api/circuitdesigner/src/tools/renderers/WiringToolRenderer.ts
+++ b/src/projects/shared/api/circuitdesigner/src/tools/renderers/WiringToolRenderer.ts
@@ -89,7 +89,7 @@ export const WiringToolRenderer = (getColor: (params: ToolRendererArgs) => strin
         const OFFSET = V(12, 0), LEN = 7.5;
 
         // Also draw checkmark or 'x' next to the cursor
-        const pos2 = viewport.camera.toScreenPos(target).add(OFFSET);
+        const pos2 = viewport.toScreenPos(target).add(OFFSET);
         if (targetCanConnectPort) {
             const POS_OFFSET = V(-1, 1), STROKE_WIDTH = 3;
 

--- a/src/projects/shared/api/circuitdesigner/tests/helpers/CreateTestCircuitDesigner.ts
+++ b/src/projects/shared/api/circuitdesigner/tests/helpers/CreateTestCircuitDesigner.ts
@@ -98,5 +98,5 @@ export function SetupMockCanvas(designer: CircuitDesigner) {
 
     designer.viewport.attachCanvas(canvas);
 
-    return [new MockInputFacade(designer.viewport.camera, canvas), canvas] as const;
+    return [new MockInputFacade(designer.viewport, canvas), canvas] as const;
 }

--- a/src/projects/shared/api/circuitdesigner/tests/helpers/MockInputFacade.ts
+++ b/src/projects/shared/api/circuitdesigner/tests/helpers/MockInputFacade.ts
@@ -1,18 +1,18 @@
 import {LEFT_MOUSE_BUTTON} from "shared/api/circuitdesigner/input/Constants";
 import {Key} from "shared/api/circuitdesigner/input/Key";
-import {Camera} from "shared/api/circuitdesigner/public/Camera";
 import {V, Vector} from "Vector";
+import {Viewport} from "shared/api/circuitdesigner/public/Viewport";
 
 
 export class MockInputFacade {
-    private readonly camera: Camera;
+    private readonly viewport: Viewport;
     private readonly canvas: HTMLCanvasElement;
 
     private touches: Vector[];
     private mousePos: Vector;
 
-    public constructor(camera: Camera, canvas: HTMLCanvasElement) {
-        this.camera = camera;
+    public constructor(viewport: Viewport, canvas: HTMLCanvasElement) {
+        this.viewport = viewport;
         this.canvas = canvas;
 
         this.touches = [];
@@ -44,7 +44,7 @@ export class MockInputFacade {
     }
 
     public click(worldPos?: Vector, button: number = LEFT_MOUSE_BUTTON): MockInputFacade {
-        const pos = (worldPos === undefined ? this.mousePos : this.camera.toScreenPos(worldPos));
+        const pos = (worldPos === undefined ? this.mousePos : this.viewport.toScreenPos(worldPos));
         this.onMouseEv("mousedown", pos, button);
         this.onMouseEv("mouseup", pos, button);
         this.onMouseEv("click", pos, button);
@@ -62,12 +62,12 @@ export class MockInputFacade {
 
     // Note that `pos` is in WORLD COORDINATES for testing purposes
     public press(worldPos?: Vector, button: number = LEFT_MOUSE_BUTTON): MockInputFacade {
-        const pos = (worldPos === undefined ? this.mousePos : this.camera.toScreenPos(worldPos));
+        const pos = (worldPos === undefined ? this.mousePos : this.viewport.toScreenPos(worldPos));
         this.onMouseEv("mousedown", pos, button);
         return this;
     }
     public move(amt: Vector, steps = 1, button: number = LEFT_MOUSE_BUTTON): MockInputFacade {
-        const step = this.camera.toScreenPos(amt).sub(this.camera.toScreenPos(V())).scale(1 / steps);
+        const step = this.viewport.toScreenPos(amt).sub(this.viewport.toScreenPos(V())).scale(1 / steps);
         for (let i = 1; i <= steps; i++)
             this.onMouseEv("mousemove", this.mousePos.add(step), button);
         return this;
@@ -75,7 +75,7 @@ export class MockInputFacade {
     public moveTo(target: Vector, steps = 5, button: number = LEFT_MOUSE_BUTTON): MockInputFacade {
         // Calculate step Vector
         // Keep in world coordinates since we're passing to `move`
-        const step = target.sub(this.camera.toWorldPos(this.mousePos)).scale(1 / steps);
+        const step = target.sub(this.viewport.toWorldPos(this.mousePos)).scale(1 / steps);
 
         // Move a bit for each step
         for (let i = 1; i <= steps; i++)
@@ -105,12 +105,12 @@ export class MockInputFacade {
     }
 
     public touch(pos: Vector): MockInputFacade {
-        this.touches.push(this.camera.toScreenPos(pos));
+        this.touches.push(this.viewport.toScreenPos(pos));
         this.onTouchEv("touchstart", this.touches);
         return this;
     }
     public moveTouch(i: number, amt: Vector, steps = 1): MockInputFacade {
-        const step = this.camera.toScreenPos(amt).sub(this.camera.toScreenPos(V())).scale(1 / steps);
+        const step = this.viewport.toScreenPos(amt).sub(this.viewport.toScreenPos(V())).scale(1 / steps);
         for (let s = 1; s <= steps; s++) {
             this.touches[i] = this.touches[i].add(step);
             this.onTouchEv("touchmove", this.touches);
@@ -132,7 +132,7 @@ export class MockInputFacade {
     public tap(pos: Vector): MockInputFacade {
         this.touch(pos);
         this.releaseTouch();
-        this.onMouseEv("click", this.camera.toScreenPos(pos), LEFT_MOUSE_BUTTON);
+        this.onMouseEv("click", this.viewport.toScreenPos(pos), LEFT_MOUSE_BUTTON);
         return this;
     }
 

--- a/src/projects/shared/api/circuitdesigner/tsconfig.json
+++ b/src/projects/shared/api/circuitdesigner/tsconfig.json
@@ -11,5 +11,5 @@
             "tests/helpers/*":                    ["./tests/helpers/*"],
         },
     },
-    "include": [".", "./src/types"],
+    "include": [".", "./src/types", "../circuit/src/public/Camera.ts", "../circuit/src/public/impl/Camera.ts"],
 }

--- a/src/projects/shared/site/src/containers/ContextMenu/index.tsx
+++ b/src/projects/shared/site/src/containers/ContextMenu/index.tsx
@@ -100,7 +100,7 @@ export const ContextMenu = ({ designer }: Props) => {
 
     /* Context Menu "Focus" */
     const onFocus = async () => {
-        FitToScreen(circuit, designer.viewport.camera, designer.viewport.margin);
+        FitToScreen(circuit, designer.viewport, designer.viewport.margin);
     }
 
     /* Context Menu "Clean Up" */

--- a/src/projects/shared/site/src/containers/Header/Right/DownloadMenuDropdown.tsx
+++ b/src/projects/shared/site/src/containers/Header/Right/DownloadMenuDropdown.tsx
@@ -20,7 +20,7 @@ export const DownloadMenuDropdown = () => {
 
     const onDownloadClick = () => {
         // Convert to URL data
-        const file = CircuitHelpers.SerializeCircuit(mainDesigner.circuit.toSchema());
+        const file = CircuitHelpers.SerializeCircuit(mainDesigner.circuit);
         const url = URL.createObjectURL(file);
 
         SaveFile(url, circuitName, "circuit");

--- a/src/projects/shared/site/src/containers/ImageExporterPopup/index.tsx
+++ b/src/projects/shared/site/src/containers/ImageExporterPopup/index.tsx
@@ -230,7 +230,7 @@ const ImageExporterPreview = ({ extraHandlers, designer: mainDesigner, canvas, w
         <img src="img/icons/fitscreen.svg"
              className="image-exporter-preview__button"
              alt="Fit to screen"
-             onClick={() => FitToScreen(designer.circuit, designer.viewport.camera, designer.viewport.margin)} />
+             onClick={() => FitToScreen(designer.circuit, designer.viewport, designer.viewport.margin)} />
         <canvas ref={canvas}
                 width={`${width}px`}
                 height={`${height}px`}

--- a/src/projects/shared/site/src/containers/MainDesigner/index.tsx
+++ b/src/projects/shared/site/src/containers/MainDesigner/index.tsx
@@ -79,7 +79,7 @@ export const MainDesigner = ({ otherPlace }: Props) => {
             throw new Error(`MainDesigner.Droppable.onDrop failed: Unknown itemKind! ${itemKind}`);
 
         const amt = (typeof num === "number" ? num : 1);
-        const pos = designer.viewport.camera.toWorldPos(
+        const pos = designer.viewport.toWorldPos(
             screenPos.sub(V(0, canvas.current.getBoundingClientRect().top)));
 
         // TODO[model_refactor](leon)

--- a/src/projects/shared/site/src/containers/SelectionPopup/index.tsx
+++ b/src/projects/shared/site/src/containers/SelectionPopup/index.tsx
@@ -24,23 +24,22 @@ type Props = {
     children: React.ReactNode;
 }
 export const SelectionPopup = ({ designer, docsUrlConfig, children }: Props) => {
-    const circuit = designer.circuit;
-    const camera = designer.viewport.camera;
+    const circuit = designer.circuit, viewport = designer.viewport;
     const itemNavCurItem = useSharedSelector((state) => state.itemNav.curItemID);
 
     const [numSelections, setNumSelections] = useState(0);
-    const [pos, setPos] = useState(camera.toScreenPos(circuit.selections.midpoint));
+    const [pos, setPos] = useState(viewport.toScreenPos(circuit.selections.midpoint));
     const [isDragging, setIsDragging] = useState(false);
     const [clickThrough, setClickThrough] = useState(false);
 
     useEffect(() => {
         // Set it initially (like when new circuit is loaded)
         setNumSelections(circuit.selections.length);
-        setPos(camera.toScreenPos(circuit.selections.midpoint));
+        setPos(viewport.toScreenPos(circuit.selections.midpoint));
 
         return circuit.selections.subscribe(() => {
             setNumSelections(circuit.selections.length);
-            setPos(camera.toScreenPos(circuit.selections.midpoint));
+            setPos(viewport.toScreenPos(circuit.selections.midpoint));
 
             // When the selection changes, reset the clickThrough state and
             // let user click through box so it doesn't block a double click
@@ -54,10 +53,10 @@ export const SelectionPopup = ({ designer, docsUrlConfig, children }: Props) => 
                 return true;
             });
         });
-    }, [circuit, camera, setNumSelections, setClickThrough]);
+    }, [circuit, viewport, setNumSelections, setClickThrough]);
 
-    useEffect(() => camera.subscribe(() =>
-        setPos(camera.toScreenPos(circuit.selections.midpoint))
+    useEffect(() => viewport.camera.subscribe(() =>
+        setPos(viewport.toScreenPos(circuit.selections.midpoint))
     ), [circuit, setPos]);
     // TODO[master] - Right now, the selection popup won't move when you edit
     //                the position values in the popup, this is kinda nice since
@@ -76,8 +75,8 @@ export const SelectionPopup = ({ designer, docsUrlConfig, children }: Props) => 
     }, designer.viewport.canvasInfo?.input, [setIsDragging]);
     useEvent("mouseup", (_) => {
         setIsDragging(false); // Show when stopped dragging
-        setPos(camera.toScreenPos(circuit.selections.midpoint)); // And recalculate position
-    }, designer.viewport.canvasInfo?.input, [circuit, camera, setPos, setIsDragging]);
+        setPos(viewport.toScreenPos(circuit.selections.midpoint)); // And recalculate position
+    }, designer.viewport.canvasInfo?.input, [circuit, viewport, setPos, setIsDragging]);
 
     const popup = useRef<HTMLDivElement>(null);
 

--- a/src/projects/shared/site/src/proto/Circuit.proto
+++ b/src/projects/shared/site/src/proto/Circuit.proto
@@ -10,6 +10,8 @@ message Prop {
 }
 
 message Port {
+    // TODO: kind?
+
     string group = 1;
     int32 index = 2;
 
@@ -41,19 +43,19 @@ message Wire {
 
     // The index of the 1st port's parent component in circuit.components
     uint32 p1ParentIdx = 2;
-    // The index of the 1st port in the parent component's ports
-    uint32 p1Idx = 3;
+    string p1Group = 3;
+    uint32 p1Idx = 4;
 
     // The index of the 2nd port's parent component in circuit.components
-    uint32 p2ParentIdx = 4;
-    // The index of the 2nd port in the parent component's ports
-    uint32 p2Idx = 5;
+    uint32 p2ParentIdx = 5;
+    string p2Group = 6;
+    uint32 p2Idx = 7;
 
-    optional string name = 6;
-    optional bool isSelected = 7;
-    optional uint32 color = 8;
+    optional string name = 8;
+    optional bool isSelected = 9;
+    optional uint32 color = 10;
 
-    map<string, Prop> otherProps = 9;
+    map<string, Prop> otherProps = 11;
 }
 
 message Camera {
@@ -77,7 +79,7 @@ message IntegratedCircuitMetadata {
     float displayHeight = 3;
 
     message Pin {
-        uint32 internalCompId = 1;
+        uint32 internalCompIdx = 1;
         uint32 internalPortIdx = 2;
 
         string group = 3;
@@ -105,6 +107,7 @@ message Circuit {
 
     repeated IntegratedCircuit ics = 3;
 
+    // Order of components will dictate the z-ordering for them.
     repeated Component components = 4;
     repeated Wire wires = 5;
 }

--- a/src/projects/shared/site/src/proto/Circuit.proto
+++ b/src/projects/shared/site/src/proto/Circuit.proto
@@ -9,30 +9,51 @@ message Prop {
     }
 }
 
+message Port {
+    string group = 1;
+    int32 index = 2;
+
+    optional string name = 3;
+    optional bool isSelected = 4;
+
+    map<string, Prop> otherProps = 5;
+}
+
 message Component {
-    bytes id = 1;
-    string kind = 2;
-    optional bytes icId = 3;
-    map<string, Prop> props = 4;
+    string kind = 1;
+
+    optional bytes icId = 2;
+
+    optional uint32 portConfigIdx = 3;
+
+    optional string name = 4;
+    optional bool isSelected = 5;
+    optional float x = 6;
+    optional float y = 7;
+    optional float angle = 8;
+
+    map<string, Prop> otherProps = 9;
+    repeated Port portOverrides = 10;
 }
 
 message Wire {
-    bytes id = 1;
-    string kind = 2;
-    map<string, Prop> props = 3;
+    optional string kind = 1;
 
-    bytes p1 = 4;
-    bytes p2 = 5;
-}
+    // The index of the 1st port's parent component in circuit.components
+    uint32 p1ParentIdx = 2;
+    // The index of the 1st port in the parent component's ports
+    uint32 p1Idx = 3;
 
-message Port {
-    bytes id = 1;
-    string kind = 2;
-    map<string, Prop> props = 3;
+    // The index of the 2nd port's parent component in circuit.components
+    uint32 p2ParentIdx = 4;
+    // The index of the 2nd port in the parent component's ports
+    uint32 p2Idx = 5;
 
-    bytes parent = 4;
-    string group = 5;
-    int32 index = 6;
+    optional string name = 6;
+    optional bool isSelected = 7;
+    optional uint32 color = 8;
+
+    map<string, Prop> otherProps = 9;
 }
 
 message Camera {
@@ -56,14 +77,16 @@ message IntegratedCircuitMetadata {
     float displayHeight = 3;
 
     message Pin {
-        bytes id = 1;
-        string group = 2;
-        string name = 3;
+        uint32 internalCompId = 1;
+        uint32 internalPortIdx = 2;
 
-        float x = 4;
-        float y = 5;
-        float dx = 6;
-        float dy = 7;
+        string group = 3;
+        string name = 4;
+
+        float x = 5;
+        float y = 6;
+        float dx = 7;
+        float dy = 8;
     }
     repeated Pin pins = 4;
 }
@@ -73,7 +96,6 @@ message IntegratedCircuit {
     
     repeated Component components = 3;
     repeated Wire wires = 4;
-    repeated Port ports = 5;
 }
 
 message Circuit {
@@ -85,5 +107,4 @@ message Circuit {
 
     repeated Component components = 4;
     repeated Wire wires = 5;
-    repeated Port ports = 6;
 }

--- a/src/projects/shared/site/src/proto/Circuit.ts
+++ b/src/projects/shared/site/src/proto/Circuit.ts
@@ -16,41 +16,56 @@ export interface Prop {
   boolVal?: boolean | undefined;
 }
 
-export interface Component {
-  id: Uint8Array;
-  kind: string;
-  icId?: Uint8Array | undefined;
-  props: { [key: string]: Prop };
+export interface Port {
+  group: string;
+  index: number;
+  name?: string | undefined;
+  isSelected?: boolean | undefined;
+  otherProps: { [key: string]: Prop };
 }
 
-export interface Component_PropsEntry {
+export interface Port_OtherPropsEntry {
+  key: string;
+  value: Prop | undefined;
+}
+
+export interface Component {
+  kind: string;
+  icId?: Uint8Array | undefined;
+  portConfigIdx?: number | undefined;
+  name?: string | undefined;
+  isSelected?: boolean | undefined;
+  x?: number | undefined;
+  y?: number | undefined;
+  angle?: number | undefined;
+  otherProps: { [key: string]: Prop };
+  portOverrides: Port[];
+}
+
+export interface Component_OtherPropsEntry {
   key: string;
   value: Prop | undefined;
 }
 
 export interface Wire {
-  id: Uint8Array;
-  kind: string;
-  props: { [key: string]: Prop };
-  p1: Uint8Array;
-  p2: Uint8Array;
+  kind?:
+    | string
+    | undefined;
+  /** The index of the 1st port's parent component in circuit.components */
+  p1ParentIdx: number;
+  /** The index of the 1st port in the parent component's ports */
+  p1Idx: number;
+  /** The index of the 2nd port's parent component in circuit.components */
+  p2ParentIdx: number;
+  /** The index of the 2nd port in the parent component's ports */
+  p2Idx: number;
+  name?: string | undefined;
+  isSelected?: boolean | undefined;
+  color?: number | undefined;
+  otherProps: { [key: string]: Prop };
 }
 
-export interface Wire_PropsEntry {
-  key: string;
-  value: Prop | undefined;
-}
-
-export interface Port {
-  id: Uint8Array;
-  kind: string;
-  props: { [key: string]: Prop };
-  parent: Uint8Array;
-  group: string;
-  index: number;
-}
-
-export interface Port_PropsEntry {
+export interface Wire_OtherPropsEntry {
   key: string;
   value: Prop | undefined;
 }
@@ -77,7 +92,8 @@ export interface IntegratedCircuitMetadata {
 }
 
 export interface IntegratedCircuitMetadata_Pin {
-  id: Uint8Array;
+  internalCompId: number;
+  internalPortIdx: number;
   group: string;
   name: string;
   x: number;
@@ -90,7 +106,6 @@ export interface IntegratedCircuit {
   metadata: IntegratedCircuitMetadata | undefined;
   components: Component[];
   wires: Wire[];
-  ports: Port[];
 }
 
 export interface Circuit {
@@ -99,7 +114,6 @@ export interface Circuit {
   ics: IntegratedCircuit[];
   components: Component[];
   wires: Wire[];
-  ports: Port[];
 }
 
 function createBaseProp(): Prop {
@@ -210,452 +224,27 @@ export const Prop: MessageFns<Prop> = {
   },
 };
 
-function createBaseComponent(): Component {
-  return { id: new Uint8Array(0), kind: "", icId: undefined, props: {} };
-}
-
-export const Component: MessageFns<Component> = {
-  encode(message: Component, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.id.length !== 0) {
-      writer.uint32(10).bytes(message.id);
-    }
-    if (message.kind !== "") {
-      writer.uint32(18).string(message.kind);
-    }
-    if (message.icId !== undefined) {
-      writer.uint32(26).bytes(message.icId);
-    }
-    Object.entries(message.props).forEach(([key, value]) => {
-      Component_PropsEntry.encode({ key: key as any, value }, writer.uint32(34).fork()).join();
-    });
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): Component {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseComponent();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.id = reader.bytes();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.kind = reader.string();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.icId = reader.bytes();
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          const entry4 = Component_PropsEntry.decode(reader, reader.uint32());
-          if (entry4.value !== undefined) {
-            message.props[entry4.key] = entry4.value;
-          }
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): Component {
-    return {
-      id: isSet(object.id) ? bytesFromBase64(object.id) : new Uint8Array(0),
-      kind: isSet(object.kind) ? globalThis.String(object.kind) : "",
-      icId: isSet(object.icId) ? bytesFromBase64(object.icId) : undefined,
-      props: isObject(object.props)
-        ? Object.entries(object.props).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
-          acc[key] = Prop.fromJSON(value);
-          return acc;
-        }, {})
-        : {},
-    };
-  },
-
-  toJSON(message: Component): unknown {
-    const obj: any = {};
-    if (message.id.length !== 0) {
-      obj.id = base64FromBytes(message.id);
-    }
-    if (message.kind !== "") {
-      obj.kind = message.kind;
-    }
-    if (message.icId !== undefined) {
-      obj.icId = base64FromBytes(message.icId);
-    }
-    if (message.props) {
-      const entries = Object.entries(message.props);
-      if (entries.length > 0) {
-        obj.props = {};
-        entries.forEach(([k, v]) => {
-          obj.props[k] = Prop.toJSON(v);
-        });
-      }
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<Component>, I>>(base?: I): Component {
-    return Component.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<Component>, I>>(object: I): Component {
-    const message = createBaseComponent();
-    message.id = object.id ?? new Uint8Array(0);
-    message.kind = object.kind ?? "";
-    message.icId = object.icId ?? undefined;
-    message.props = Object.entries(object.props ?? {}).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = Prop.fromPartial(value);
-      }
-      return acc;
-    }, {});
-    return message;
-  },
-};
-
-function createBaseComponent_PropsEntry(): Component_PropsEntry {
-  return { key: "", value: undefined };
-}
-
-export const Component_PropsEntry: MessageFns<Component_PropsEntry> = {
-  encode(message: Component_PropsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.key !== "") {
-      writer.uint32(10).string(message.key);
-    }
-    if (message.value !== undefined) {
-      Prop.encode(message.value, writer.uint32(18).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): Component_PropsEntry {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseComponent_PropsEntry();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.key = reader.string();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.value = Prop.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): Component_PropsEntry {
-    return {
-      key: isSet(object.key) ? globalThis.String(object.key) : "",
-      value: isSet(object.value) ? Prop.fromJSON(object.value) : undefined,
-    };
-  },
-
-  toJSON(message: Component_PropsEntry): unknown {
-    const obj: any = {};
-    if (message.key !== "") {
-      obj.key = message.key;
-    }
-    if (message.value !== undefined) {
-      obj.value = Prop.toJSON(message.value);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<Component_PropsEntry>, I>>(base?: I): Component_PropsEntry {
-    return Component_PropsEntry.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<Component_PropsEntry>, I>>(object: I): Component_PropsEntry {
-    const message = createBaseComponent_PropsEntry();
-    message.key = object.key ?? "";
-    message.value = (object.value !== undefined && object.value !== null) ? Prop.fromPartial(object.value) : undefined;
-    return message;
-  },
-};
-
-function createBaseWire(): Wire {
-  return { id: new Uint8Array(0), kind: "", props: {}, p1: new Uint8Array(0), p2: new Uint8Array(0) };
-}
-
-export const Wire: MessageFns<Wire> = {
-  encode(message: Wire, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.id.length !== 0) {
-      writer.uint32(10).bytes(message.id);
-    }
-    if (message.kind !== "") {
-      writer.uint32(18).string(message.kind);
-    }
-    Object.entries(message.props).forEach(([key, value]) => {
-      Wire_PropsEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
-    });
-    if (message.p1.length !== 0) {
-      writer.uint32(34).bytes(message.p1);
-    }
-    if (message.p2.length !== 0) {
-      writer.uint32(42).bytes(message.p2);
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): Wire {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseWire();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.id = reader.bytes();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.kind = reader.string();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          const entry3 = Wire_PropsEntry.decode(reader, reader.uint32());
-          if (entry3.value !== undefined) {
-            message.props[entry3.key] = entry3.value;
-          }
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.p1 = reader.bytes();
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.p2 = reader.bytes();
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): Wire {
-    return {
-      id: isSet(object.id) ? bytesFromBase64(object.id) : new Uint8Array(0),
-      kind: isSet(object.kind) ? globalThis.String(object.kind) : "",
-      props: isObject(object.props)
-        ? Object.entries(object.props).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
-          acc[key] = Prop.fromJSON(value);
-          return acc;
-        }, {})
-        : {},
-      p1: isSet(object.p1) ? bytesFromBase64(object.p1) : new Uint8Array(0),
-      p2: isSet(object.p2) ? bytesFromBase64(object.p2) : new Uint8Array(0),
-    };
-  },
-
-  toJSON(message: Wire): unknown {
-    const obj: any = {};
-    if (message.id.length !== 0) {
-      obj.id = base64FromBytes(message.id);
-    }
-    if (message.kind !== "") {
-      obj.kind = message.kind;
-    }
-    if (message.props) {
-      const entries = Object.entries(message.props);
-      if (entries.length > 0) {
-        obj.props = {};
-        entries.forEach(([k, v]) => {
-          obj.props[k] = Prop.toJSON(v);
-        });
-      }
-    }
-    if (message.p1.length !== 0) {
-      obj.p1 = base64FromBytes(message.p1);
-    }
-    if (message.p2.length !== 0) {
-      obj.p2 = base64FromBytes(message.p2);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<Wire>, I>>(base?: I): Wire {
-    return Wire.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<Wire>, I>>(object: I): Wire {
-    const message = createBaseWire();
-    message.id = object.id ?? new Uint8Array(0);
-    message.kind = object.kind ?? "";
-    message.props = Object.entries(object.props ?? {}).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = Prop.fromPartial(value);
-      }
-      return acc;
-    }, {});
-    message.p1 = object.p1 ?? new Uint8Array(0);
-    message.p2 = object.p2 ?? new Uint8Array(0);
-    return message;
-  },
-};
-
-function createBaseWire_PropsEntry(): Wire_PropsEntry {
-  return { key: "", value: undefined };
-}
-
-export const Wire_PropsEntry: MessageFns<Wire_PropsEntry> = {
-  encode(message: Wire_PropsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.key !== "") {
-      writer.uint32(10).string(message.key);
-    }
-    if (message.value !== undefined) {
-      Prop.encode(message.value, writer.uint32(18).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): Wire_PropsEntry {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseWire_PropsEntry();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.key = reader.string();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.value = Prop.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): Wire_PropsEntry {
-    return {
-      key: isSet(object.key) ? globalThis.String(object.key) : "",
-      value: isSet(object.value) ? Prop.fromJSON(object.value) : undefined,
-    };
-  },
-
-  toJSON(message: Wire_PropsEntry): unknown {
-    const obj: any = {};
-    if (message.key !== "") {
-      obj.key = message.key;
-    }
-    if (message.value !== undefined) {
-      obj.value = Prop.toJSON(message.value);
-    }
-    return obj;
-  },
-
-  create<I extends Exact<DeepPartial<Wire_PropsEntry>, I>>(base?: I): Wire_PropsEntry {
-    return Wire_PropsEntry.fromPartial(base ?? ({} as any));
-  },
-  fromPartial<I extends Exact<DeepPartial<Wire_PropsEntry>, I>>(object: I): Wire_PropsEntry {
-    const message = createBaseWire_PropsEntry();
-    message.key = object.key ?? "";
-    message.value = (object.value !== undefined && object.value !== null) ? Prop.fromPartial(object.value) : undefined;
-    return message;
-  },
-};
-
 function createBasePort(): Port {
-  return { id: new Uint8Array(0), kind: "", props: {}, parent: new Uint8Array(0), group: "", index: 0 };
+  return { group: "", index: 0, name: undefined, isSelected: undefined, otherProps: {} };
 }
 
 export const Port: MessageFns<Port> = {
   encode(message: Port, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.id.length !== 0) {
-      writer.uint32(10).bytes(message.id);
-    }
-    if (message.kind !== "") {
-      writer.uint32(18).string(message.kind);
-    }
-    Object.entries(message.props).forEach(([key, value]) => {
-      Port_PropsEntry.encode({ key: key as any, value }, writer.uint32(26).fork()).join();
-    });
-    if (message.parent.length !== 0) {
-      writer.uint32(34).bytes(message.parent);
-    }
     if (message.group !== "") {
-      writer.uint32(42).string(message.group);
+      writer.uint32(10).string(message.group);
     }
     if (message.index !== 0) {
-      writer.uint32(48).int32(message.index);
+      writer.uint32(16).int32(message.index);
     }
+    if (message.name !== undefined) {
+      writer.uint32(26).string(message.name);
+    }
+    if (message.isSelected !== undefined) {
+      writer.uint32(32).bool(message.isSelected);
+    }
+    Object.entries(message.otherProps).forEach(([key, value]) => {
+      Port_OtherPropsEntry.encode({ key: key as any, value }, writer.uint32(42).fork()).join();
+    });
     return writer;
   },
 
@@ -671,15 +260,15 @@ export const Port: MessageFns<Port> = {
             break;
           }
 
-          message.id = reader.bytes();
+          message.group = reader.string();
           continue;
         }
         case 2: {
-          if (tag !== 18) {
+          if (tag !== 16) {
             break;
           }
 
-          message.kind = reader.string();
+          message.index = reader.int32();
           continue;
         }
         case 3: {
@@ -687,18 +276,15 @@ export const Port: MessageFns<Port> = {
             break;
           }
 
-          const entry3 = Port_PropsEntry.decode(reader, reader.uint32());
-          if (entry3.value !== undefined) {
-            message.props[entry3.key] = entry3.value;
-          }
+          message.name = reader.string();
           continue;
         }
         case 4: {
-          if (tag !== 34) {
+          if (tag !== 32) {
             break;
           }
 
-          message.parent = reader.bytes();
+          message.isSelected = reader.bool();
           continue;
         }
         case 5: {
@@ -706,15 +292,10 @@ export const Port: MessageFns<Port> = {
             break;
           }
 
-          message.group = reader.string();
-          continue;
-        }
-        case 6: {
-          if (tag !== 48) {
-            break;
+          const entry5 = Port_OtherPropsEntry.decode(reader, reader.uint32());
+          if (entry5.value !== undefined) {
+            message.otherProps[entry5.key] = entry5.value;
           }
-
-          message.index = reader.int32();
           continue;
         }
       }
@@ -728,45 +309,41 @@ export const Port: MessageFns<Port> = {
 
   fromJSON(object: any): Port {
     return {
-      id: isSet(object.id) ? bytesFromBase64(object.id) : new Uint8Array(0),
-      kind: isSet(object.kind) ? globalThis.String(object.kind) : "",
-      props: isObject(object.props)
-        ? Object.entries(object.props).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
+      group: isSet(object.group) ? globalThis.String(object.group) : "",
+      index: isSet(object.index) ? globalThis.Number(object.index) : 0,
+      name: isSet(object.name) ? globalThis.String(object.name) : undefined,
+      isSelected: isSet(object.isSelected) ? globalThis.Boolean(object.isSelected) : undefined,
+      otherProps: isObject(object.otherProps)
+        ? Object.entries(object.otherProps).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
           acc[key] = Prop.fromJSON(value);
           return acc;
         }, {})
         : {},
-      parent: isSet(object.parent) ? bytesFromBase64(object.parent) : new Uint8Array(0),
-      group: isSet(object.group) ? globalThis.String(object.group) : "",
-      index: isSet(object.index) ? globalThis.Number(object.index) : 0,
     };
   },
 
   toJSON(message: Port): unknown {
     const obj: any = {};
-    if (message.id.length !== 0) {
-      obj.id = base64FromBytes(message.id);
-    }
-    if (message.kind !== "") {
-      obj.kind = message.kind;
-    }
-    if (message.props) {
-      const entries = Object.entries(message.props);
-      if (entries.length > 0) {
-        obj.props = {};
-        entries.forEach(([k, v]) => {
-          obj.props[k] = Prop.toJSON(v);
-        });
-      }
-    }
-    if (message.parent.length !== 0) {
-      obj.parent = base64FromBytes(message.parent);
-    }
     if (message.group !== "") {
       obj.group = message.group;
     }
     if (message.index !== 0) {
       obj.index = Math.round(message.index);
+    }
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.isSelected !== undefined) {
+      obj.isSelected = message.isSelected;
+    }
+    if (message.otherProps) {
+      const entries = Object.entries(message.otherProps);
+      if (entries.length > 0) {
+        obj.otherProps = {};
+        entries.forEach(([k, v]) => {
+          obj.otherProps[k] = Prop.toJSON(v);
+        });
+      }
     }
     return obj;
   },
@@ -776,27 +353,29 @@ export const Port: MessageFns<Port> = {
   },
   fromPartial<I extends Exact<DeepPartial<Port>, I>>(object: I): Port {
     const message = createBasePort();
-    message.id = object.id ?? new Uint8Array(0);
-    message.kind = object.kind ?? "";
-    message.props = Object.entries(object.props ?? {}).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
-      if (value !== undefined) {
-        acc[key] = Prop.fromPartial(value);
-      }
-      return acc;
-    }, {});
-    message.parent = object.parent ?? new Uint8Array(0);
     message.group = object.group ?? "";
     message.index = object.index ?? 0;
+    message.name = object.name ?? undefined;
+    message.isSelected = object.isSelected ?? undefined;
+    message.otherProps = Object.entries(object.otherProps ?? {}).reduce<{ [key: string]: Prop }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = Prop.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
     return message;
   },
 };
 
-function createBasePort_PropsEntry(): Port_PropsEntry {
+function createBasePort_OtherPropsEntry(): Port_OtherPropsEntry {
   return { key: "", value: undefined };
 }
 
-export const Port_PropsEntry: MessageFns<Port_PropsEntry> = {
-  encode(message: Port_PropsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+export const Port_OtherPropsEntry: MessageFns<Port_OtherPropsEntry> = {
+  encode(message: Port_OtherPropsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.key !== "") {
       writer.uint32(10).string(message.key);
     }
@@ -806,10 +385,10 @@ export const Port_PropsEntry: MessageFns<Port_PropsEntry> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): Port_PropsEntry {
+  decode(input: BinaryReader | Uint8Array, length?: number): Port_OtherPropsEntry {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBasePort_PropsEntry();
+    const message = createBasePort_OtherPropsEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -838,14 +417,14 @@ export const Port_PropsEntry: MessageFns<Port_PropsEntry> = {
     return message;
   },
 
-  fromJSON(object: any): Port_PropsEntry {
+  fromJSON(object: any): Port_OtherPropsEntry {
     return {
       key: isSet(object.key) ? globalThis.String(object.key) : "",
       value: isSet(object.value) ? Prop.fromJSON(object.value) : undefined,
     };
   },
 
-  toJSON(message: Port_PropsEntry): unknown {
+  toJSON(message: Port_OtherPropsEntry): unknown {
     const obj: any = {};
     if (message.key !== "") {
       obj.key = message.key;
@@ -856,11 +435,622 @@ export const Port_PropsEntry: MessageFns<Port_PropsEntry> = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<Port_PropsEntry>, I>>(base?: I): Port_PropsEntry {
-    return Port_PropsEntry.fromPartial(base ?? ({} as any));
+  create<I extends Exact<DeepPartial<Port_OtherPropsEntry>, I>>(base?: I): Port_OtherPropsEntry {
+    return Port_OtherPropsEntry.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<Port_PropsEntry>, I>>(object: I): Port_PropsEntry {
-    const message = createBasePort_PropsEntry();
+  fromPartial<I extends Exact<DeepPartial<Port_OtherPropsEntry>, I>>(object: I): Port_OtherPropsEntry {
+    const message = createBasePort_OtherPropsEntry();
+    message.key = object.key ?? "";
+    message.value = (object.value !== undefined && object.value !== null) ? Prop.fromPartial(object.value) : undefined;
+    return message;
+  },
+};
+
+function createBaseComponent(): Component {
+  return {
+    kind: "",
+    icId: undefined,
+    portConfigIdx: undefined,
+    name: undefined,
+    isSelected: undefined,
+    x: undefined,
+    y: undefined,
+    angle: undefined,
+    otherProps: {},
+    portOverrides: [],
+  };
+}
+
+export const Component: MessageFns<Component> = {
+  encode(message: Component, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.kind !== "") {
+      writer.uint32(10).string(message.kind);
+    }
+    if (message.icId !== undefined) {
+      writer.uint32(18).bytes(message.icId);
+    }
+    if (message.portConfigIdx !== undefined) {
+      writer.uint32(24).uint32(message.portConfigIdx);
+    }
+    if (message.name !== undefined) {
+      writer.uint32(34).string(message.name);
+    }
+    if (message.isSelected !== undefined) {
+      writer.uint32(40).bool(message.isSelected);
+    }
+    if (message.x !== undefined) {
+      writer.uint32(53).float(message.x);
+    }
+    if (message.y !== undefined) {
+      writer.uint32(61).float(message.y);
+    }
+    if (message.angle !== undefined) {
+      writer.uint32(69).float(message.angle);
+    }
+    Object.entries(message.otherProps).forEach(([key, value]) => {
+      Component_OtherPropsEntry.encode({ key: key as any, value }, writer.uint32(74).fork()).join();
+    });
+    for (const v of message.portOverrides) {
+      Port.encode(v!, writer.uint32(82).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Component {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseComponent();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.kind = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.icId = reader.bytes();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.portConfigIdx = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.isSelected = reader.bool();
+          continue;
+        }
+        case 6: {
+          if (tag !== 53) {
+            break;
+          }
+
+          message.x = reader.float();
+          continue;
+        }
+        case 7: {
+          if (tag !== 61) {
+            break;
+          }
+
+          message.y = reader.float();
+          continue;
+        }
+        case 8: {
+          if (tag !== 69) {
+            break;
+          }
+
+          message.angle = reader.float();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          const entry9 = Component_OtherPropsEntry.decode(reader, reader.uint32());
+          if (entry9.value !== undefined) {
+            message.otherProps[entry9.key] = entry9.value;
+          }
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.portOverrides.push(Port.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Component {
+    return {
+      kind: isSet(object.kind) ? globalThis.String(object.kind) : "",
+      icId: isSet(object.icId) ? bytesFromBase64(object.icId) : undefined,
+      portConfigIdx: isSet(object.portConfigIdx) ? globalThis.Number(object.portConfigIdx) : undefined,
+      name: isSet(object.name) ? globalThis.String(object.name) : undefined,
+      isSelected: isSet(object.isSelected) ? globalThis.Boolean(object.isSelected) : undefined,
+      x: isSet(object.x) ? globalThis.Number(object.x) : undefined,
+      y: isSet(object.y) ? globalThis.Number(object.y) : undefined,
+      angle: isSet(object.angle) ? globalThis.Number(object.angle) : undefined,
+      otherProps: isObject(object.otherProps)
+        ? Object.entries(object.otherProps).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
+          acc[key] = Prop.fromJSON(value);
+          return acc;
+        }, {})
+        : {},
+      portOverrides: globalThis.Array.isArray(object?.portOverrides)
+        ? object.portOverrides.map((e: any) => Port.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: Component): unknown {
+    const obj: any = {};
+    if (message.kind !== "") {
+      obj.kind = message.kind;
+    }
+    if (message.icId !== undefined) {
+      obj.icId = base64FromBytes(message.icId);
+    }
+    if (message.portConfigIdx !== undefined) {
+      obj.portConfigIdx = Math.round(message.portConfigIdx);
+    }
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.isSelected !== undefined) {
+      obj.isSelected = message.isSelected;
+    }
+    if (message.x !== undefined) {
+      obj.x = message.x;
+    }
+    if (message.y !== undefined) {
+      obj.y = message.y;
+    }
+    if (message.angle !== undefined) {
+      obj.angle = message.angle;
+    }
+    if (message.otherProps) {
+      const entries = Object.entries(message.otherProps);
+      if (entries.length > 0) {
+        obj.otherProps = {};
+        entries.forEach(([k, v]) => {
+          obj.otherProps[k] = Prop.toJSON(v);
+        });
+      }
+    }
+    if (message.portOverrides?.length) {
+      obj.portOverrides = message.portOverrides.map((e) => Port.toJSON(e));
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Component>, I>>(base?: I): Component {
+    return Component.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Component>, I>>(object: I): Component {
+    const message = createBaseComponent();
+    message.kind = object.kind ?? "";
+    message.icId = object.icId ?? undefined;
+    message.portConfigIdx = object.portConfigIdx ?? undefined;
+    message.name = object.name ?? undefined;
+    message.isSelected = object.isSelected ?? undefined;
+    message.x = object.x ?? undefined;
+    message.y = object.y ?? undefined;
+    message.angle = object.angle ?? undefined;
+    message.otherProps = Object.entries(object.otherProps ?? {}).reduce<{ [key: string]: Prop }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = Prop.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    message.portOverrides = object.portOverrides?.map((e) => Port.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseComponent_OtherPropsEntry(): Component_OtherPropsEntry {
+  return { key: "", value: undefined };
+}
+
+export const Component_OtherPropsEntry: MessageFns<Component_OtherPropsEntry> = {
+  encode(message: Component_OtherPropsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      Prop.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Component_OtherPropsEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseComponent_OtherPropsEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = Prop.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Component_OtherPropsEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? Prop.fromJSON(object.value) : undefined,
+    };
+  },
+
+  toJSON(message: Component_OtherPropsEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = Prop.toJSON(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Component_OtherPropsEntry>, I>>(base?: I): Component_OtherPropsEntry {
+    return Component_OtherPropsEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Component_OtherPropsEntry>, I>>(object: I): Component_OtherPropsEntry {
+    const message = createBaseComponent_OtherPropsEntry();
+    message.key = object.key ?? "";
+    message.value = (object.value !== undefined && object.value !== null) ? Prop.fromPartial(object.value) : undefined;
+    return message;
+  },
+};
+
+function createBaseWire(): Wire {
+  return {
+    kind: undefined,
+    p1ParentIdx: 0,
+    p1Idx: 0,
+    p2ParentIdx: 0,
+    p2Idx: 0,
+    name: undefined,
+    isSelected: undefined,
+    color: undefined,
+    otherProps: {},
+  };
+}
+
+export const Wire: MessageFns<Wire> = {
+  encode(message: Wire, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.kind !== undefined) {
+      writer.uint32(10).string(message.kind);
+    }
+    if (message.p1ParentIdx !== 0) {
+      writer.uint32(16).uint32(message.p1ParentIdx);
+    }
+    if (message.p1Idx !== 0) {
+      writer.uint32(24).uint32(message.p1Idx);
+    }
+    if (message.p2ParentIdx !== 0) {
+      writer.uint32(32).uint32(message.p2ParentIdx);
+    }
+    if (message.p2Idx !== 0) {
+      writer.uint32(40).uint32(message.p2Idx);
+    }
+    if (message.name !== undefined) {
+      writer.uint32(50).string(message.name);
+    }
+    if (message.isSelected !== undefined) {
+      writer.uint32(56).bool(message.isSelected);
+    }
+    if (message.color !== undefined) {
+      writer.uint32(64).uint32(message.color);
+    }
+    Object.entries(message.otherProps).forEach(([key, value]) => {
+      Wire_OtherPropsEntry.encode({ key: key as any, value }, writer.uint32(74).fork()).join();
+    });
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Wire {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseWire();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.kind = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.p1ParentIdx = reader.uint32();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.p1Idx = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.p2ParentIdx = reader.uint32();
+          continue;
+        }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.p2Idx = reader.uint32();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.isSelected = reader.bool();
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.color = reader.uint32();
+          continue;
+        }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          const entry9 = Wire_OtherPropsEntry.decode(reader, reader.uint32());
+          if (entry9.value !== undefined) {
+            message.otherProps[entry9.key] = entry9.value;
+          }
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Wire {
+    return {
+      kind: isSet(object.kind) ? globalThis.String(object.kind) : undefined,
+      p1ParentIdx: isSet(object.p1ParentIdx) ? globalThis.Number(object.p1ParentIdx) : 0,
+      p1Idx: isSet(object.p1Idx) ? globalThis.Number(object.p1Idx) : 0,
+      p2ParentIdx: isSet(object.p2ParentIdx) ? globalThis.Number(object.p2ParentIdx) : 0,
+      p2Idx: isSet(object.p2Idx) ? globalThis.Number(object.p2Idx) : 0,
+      name: isSet(object.name) ? globalThis.String(object.name) : undefined,
+      isSelected: isSet(object.isSelected) ? globalThis.Boolean(object.isSelected) : undefined,
+      color: isSet(object.color) ? globalThis.Number(object.color) : undefined,
+      otherProps: isObject(object.otherProps)
+        ? Object.entries(object.otherProps).reduce<{ [key: string]: Prop }>((acc, [key, value]) => {
+          acc[key] = Prop.fromJSON(value);
+          return acc;
+        }, {})
+        : {},
+    };
+  },
+
+  toJSON(message: Wire): unknown {
+    const obj: any = {};
+    if (message.kind !== undefined) {
+      obj.kind = message.kind;
+    }
+    if (message.p1ParentIdx !== 0) {
+      obj.p1ParentIdx = Math.round(message.p1ParentIdx);
+    }
+    if (message.p1Idx !== 0) {
+      obj.p1Idx = Math.round(message.p1Idx);
+    }
+    if (message.p2ParentIdx !== 0) {
+      obj.p2ParentIdx = Math.round(message.p2ParentIdx);
+    }
+    if (message.p2Idx !== 0) {
+      obj.p2Idx = Math.round(message.p2Idx);
+    }
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.isSelected !== undefined) {
+      obj.isSelected = message.isSelected;
+    }
+    if (message.color !== undefined) {
+      obj.color = Math.round(message.color);
+    }
+    if (message.otherProps) {
+      const entries = Object.entries(message.otherProps);
+      if (entries.length > 0) {
+        obj.otherProps = {};
+        entries.forEach(([k, v]) => {
+          obj.otherProps[k] = Prop.toJSON(v);
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Wire>, I>>(base?: I): Wire {
+    return Wire.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Wire>, I>>(object: I): Wire {
+    const message = createBaseWire();
+    message.kind = object.kind ?? undefined;
+    message.p1ParentIdx = object.p1ParentIdx ?? 0;
+    message.p1Idx = object.p1Idx ?? 0;
+    message.p2ParentIdx = object.p2ParentIdx ?? 0;
+    message.p2Idx = object.p2Idx ?? 0;
+    message.name = object.name ?? undefined;
+    message.isSelected = object.isSelected ?? undefined;
+    message.color = object.color ?? undefined;
+    message.otherProps = Object.entries(object.otherProps ?? {}).reduce<{ [key: string]: Prop }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = Prop.fromPartial(value);
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+};
+
+function createBaseWire_OtherPropsEntry(): Wire_OtherPropsEntry {
+  return { key: "", value: undefined };
+}
+
+export const Wire_OtherPropsEntry: MessageFns<Wire_OtherPropsEntry> = {
+  encode(message: Wire_OtherPropsEntry, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      Prop.encode(message.value, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Wire_OtherPropsEntry {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseWire_OtherPropsEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = Prop.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Wire_OtherPropsEntry {
+    return {
+      key: isSet(object.key) ? globalThis.String(object.key) : "",
+      value: isSet(object.value) ? Prop.fromJSON(object.value) : undefined,
+    };
+  },
+
+  toJSON(message: Wire_OtherPropsEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = Prop.toJSON(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Wire_OtherPropsEntry>, I>>(base?: I): Wire_OtherPropsEntry {
+    return Wire_OtherPropsEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Wire_OtherPropsEntry>, I>>(object: I): Wire_OtherPropsEntry {
+    const message = createBaseWire_OtherPropsEntry();
     message.key = object.key ?? "";
     message.value = (object.value !== undefined && object.value !== null) ? Prop.fromPartial(object.value) : undefined;
     return message;
@@ -1196,31 +1386,34 @@ export const IntegratedCircuitMetadata: MessageFns<IntegratedCircuitMetadata> = 
 };
 
 function createBaseIntegratedCircuitMetadata_Pin(): IntegratedCircuitMetadata_Pin {
-  return { id: new Uint8Array(0), group: "", name: "", x: 0, y: 0, dx: 0, dy: 0 };
+  return { internalCompId: 0, internalPortIdx: 0, group: "", name: "", x: 0, y: 0, dx: 0, dy: 0 };
 }
 
 export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata_Pin> = {
   encode(message: IntegratedCircuitMetadata_Pin, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.id.length !== 0) {
-      writer.uint32(10).bytes(message.id);
+    if (message.internalCompId !== 0) {
+      writer.uint32(8).uint32(message.internalCompId);
+    }
+    if (message.internalPortIdx !== 0) {
+      writer.uint32(16).uint32(message.internalPortIdx);
     }
     if (message.group !== "") {
-      writer.uint32(18).string(message.group);
+      writer.uint32(26).string(message.group);
     }
     if (message.name !== "") {
-      writer.uint32(26).string(message.name);
+      writer.uint32(34).string(message.name);
     }
     if (message.x !== 0) {
-      writer.uint32(37).float(message.x);
+      writer.uint32(45).float(message.x);
     }
     if (message.y !== 0) {
-      writer.uint32(45).float(message.y);
+      writer.uint32(53).float(message.y);
     }
     if (message.dx !== 0) {
-      writer.uint32(53).float(message.dx);
+      writer.uint32(61).float(message.dx);
     }
     if (message.dy !== 0) {
-      writer.uint32(61).float(message.dy);
+      writer.uint32(69).float(message.dy);
     }
     return writer;
   },
@@ -1233,19 +1426,19 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1: {
-          if (tag !== 10) {
+          if (tag !== 8) {
             break;
           }
 
-          message.id = reader.bytes();
+          message.internalCompId = reader.uint32();
           continue;
         }
         case 2: {
-          if (tag !== 18) {
+          if (tag !== 16) {
             break;
           }
 
-          message.group = reader.string();
+          message.internalPortIdx = reader.uint32();
           continue;
         }
         case 3: {
@@ -1253,15 +1446,15 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
             break;
           }
 
-          message.name = reader.string();
+          message.group = reader.string();
           continue;
         }
         case 4: {
-          if (tag !== 37) {
+          if (tag !== 34) {
             break;
           }
 
-          message.x = reader.float();
+          message.name = reader.string();
           continue;
         }
         case 5: {
@@ -1269,7 +1462,7 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
             break;
           }
 
-          message.y = reader.float();
+          message.x = reader.float();
           continue;
         }
         case 6: {
@@ -1277,11 +1470,19 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
             break;
           }
 
-          message.dx = reader.float();
+          message.y = reader.float();
           continue;
         }
         case 7: {
           if (tag !== 61) {
+            break;
+          }
+
+          message.dx = reader.float();
+          continue;
+        }
+        case 8: {
+          if (tag !== 69) {
             break;
           }
 
@@ -1299,7 +1500,8 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
 
   fromJSON(object: any): IntegratedCircuitMetadata_Pin {
     return {
-      id: isSet(object.id) ? bytesFromBase64(object.id) : new Uint8Array(0),
+      internalCompId: isSet(object.internalCompId) ? globalThis.Number(object.internalCompId) : 0,
+      internalPortIdx: isSet(object.internalPortIdx) ? globalThis.Number(object.internalPortIdx) : 0,
       group: isSet(object.group) ? globalThis.String(object.group) : "",
       name: isSet(object.name) ? globalThis.String(object.name) : "",
       x: isSet(object.x) ? globalThis.Number(object.x) : 0,
@@ -1311,8 +1513,11 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
 
   toJSON(message: IntegratedCircuitMetadata_Pin): unknown {
     const obj: any = {};
-    if (message.id.length !== 0) {
-      obj.id = base64FromBytes(message.id);
+    if (message.internalCompId !== 0) {
+      obj.internalCompId = Math.round(message.internalCompId);
+    }
+    if (message.internalPortIdx !== 0) {
+      obj.internalPortIdx = Math.round(message.internalPortIdx);
     }
     if (message.group !== "") {
       obj.group = message.group;
@@ -1342,7 +1547,8 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
     object: I,
   ): IntegratedCircuitMetadata_Pin {
     const message = createBaseIntegratedCircuitMetadata_Pin();
-    message.id = object.id ?? new Uint8Array(0);
+    message.internalCompId = object.internalCompId ?? 0;
+    message.internalPortIdx = object.internalPortIdx ?? 0;
     message.group = object.group ?? "";
     message.name = object.name ?? "";
     message.x = object.x ?? 0;
@@ -1354,7 +1560,7 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
 };
 
 function createBaseIntegratedCircuit(): IntegratedCircuit {
-  return { metadata: undefined, components: [], wires: [], ports: [] };
+  return { metadata: undefined, components: [], wires: [] };
 }
 
 export const IntegratedCircuit: MessageFns<IntegratedCircuit> = {
@@ -1367,9 +1573,6 @@ export const IntegratedCircuit: MessageFns<IntegratedCircuit> = {
     }
     for (const v of message.wires) {
       Wire.encode(v!, writer.uint32(34).fork()).join();
-    }
-    for (const v of message.ports) {
-      Port.encode(v!, writer.uint32(42).fork()).join();
     }
     return writer;
   },
@@ -1405,14 +1608,6 @@ export const IntegratedCircuit: MessageFns<IntegratedCircuit> = {
           message.wires.push(Wire.decode(reader, reader.uint32()));
           continue;
         }
-        case 5: {
-          if (tag !== 42) {
-            break;
-          }
-
-          message.ports.push(Port.decode(reader, reader.uint32()));
-          continue;
-        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1429,7 +1624,6 @@ export const IntegratedCircuit: MessageFns<IntegratedCircuit> = {
         ? object.components.map((e: any) => Component.fromJSON(e))
         : [],
       wires: globalThis.Array.isArray(object?.wires) ? object.wires.map((e: any) => Wire.fromJSON(e)) : [],
-      ports: globalThis.Array.isArray(object?.ports) ? object.ports.map((e: any) => Port.fromJSON(e)) : [],
     };
   },
 
@@ -1444,9 +1638,6 @@ export const IntegratedCircuit: MessageFns<IntegratedCircuit> = {
     if (message.wires?.length) {
       obj.wires = message.wires.map((e) => Wire.toJSON(e));
     }
-    if (message.ports?.length) {
-      obj.ports = message.ports.map((e) => Port.toJSON(e));
-    }
     return obj;
   },
 
@@ -1460,13 +1651,12 @@ export const IntegratedCircuit: MessageFns<IntegratedCircuit> = {
       : undefined;
     message.components = object.components?.map((e) => Component.fromPartial(e)) || [];
     message.wires = object.wires?.map((e) => Wire.fromPartial(e)) || [];
-    message.ports = object.ports?.map((e) => Port.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseCircuit(): Circuit {
-  return { metadata: undefined, camera: undefined, ics: [], components: [], wires: [], ports: [] };
+  return { metadata: undefined, camera: undefined, ics: [], components: [], wires: [] };
 }
 
 export const Circuit: MessageFns<Circuit> = {
@@ -1485,9 +1675,6 @@ export const Circuit: MessageFns<Circuit> = {
     }
     for (const v of message.wires) {
       Wire.encode(v!, writer.uint32(42).fork()).join();
-    }
-    for (const v of message.ports) {
-      Port.encode(v!, writer.uint32(50).fork()).join();
     }
     return writer;
   },
@@ -1539,14 +1726,6 @@ export const Circuit: MessageFns<Circuit> = {
           message.wires.push(Wire.decode(reader, reader.uint32()));
           continue;
         }
-        case 6: {
-          if (tag !== 50) {
-            break;
-          }
-
-          message.ports.push(Port.decode(reader, reader.uint32()));
-          continue;
-        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1565,7 +1744,6 @@ export const Circuit: MessageFns<Circuit> = {
         ? object.components.map((e: any) => Component.fromJSON(e))
         : [],
       wires: globalThis.Array.isArray(object?.wires) ? object.wires.map((e: any) => Wire.fromJSON(e)) : [],
-      ports: globalThis.Array.isArray(object?.ports) ? object.ports.map((e: any) => Port.fromJSON(e)) : [],
     };
   },
 
@@ -1586,9 +1764,6 @@ export const Circuit: MessageFns<Circuit> = {
     if (message.wires?.length) {
       obj.wires = message.wires.map((e) => Wire.toJSON(e));
     }
-    if (message.ports?.length) {
-      obj.ports = message.ports.map((e) => Port.toJSON(e));
-    }
     return obj;
   },
 
@@ -1606,7 +1781,6 @@ export const Circuit: MessageFns<Circuit> = {
     message.ics = object.ics?.map((e) => IntegratedCircuit.fromPartial(e)) || [];
     message.components = object.components?.map((e) => Component.fromPartial(e)) || [];
     message.wires = object.wires?.map((e) => Wire.fromPartial(e)) || [];
-    message.ports = object.ports?.map((e) => Port.fromPartial(e)) || [];
     return message;
   },
 };

--- a/src/projects/shared/site/src/proto/Circuit.ts
+++ b/src/projects/shared/site/src/proto/Circuit.ts
@@ -16,6 +16,7 @@ export interface Prop {
   boolVal?: boolean | undefined;
 }
 
+/** TODO: kind? */
 export interface Port {
   group: string;
   index: number;
@@ -53,11 +54,11 @@ export interface Wire {
     | undefined;
   /** The index of the 1st port's parent component in circuit.components */
   p1ParentIdx: number;
-  /** The index of the 1st port in the parent component's ports */
+  p1Group: string;
   p1Idx: number;
   /** The index of the 2nd port's parent component in circuit.components */
   p2ParentIdx: number;
-  /** The index of the 2nd port in the parent component's ports */
+  p2Group: string;
   p2Idx: number;
   name?: string | undefined;
   isSelected?: boolean | undefined;
@@ -92,7 +93,7 @@ export interface IntegratedCircuitMetadata {
 }
 
 export interface IntegratedCircuitMetadata_Pin {
-  internalCompId: number;
+  internalCompIdx: number;
   internalPortIdx: number;
   group: string;
   name: string;
@@ -765,8 +766,10 @@ function createBaseWire(): Wire {
   return {
     kind: undefined,
     p1ParentIdx: 0,
+    p1Group: "",
     p1Idx: 0,
     p2ParentIdx: 0,
+    p2Group: "",
     p2Idx: 0,
     name: undefined,
     isSelected: undefined,
@@ -783,26 +786,32 @@ export const Wire: MessageFns<Wire> = {
     if (message.p1ParentIdx !== 0) {
       writer.uint32(16).uint32(message.p1ParentIdx);
     }
+    if (message.p1Group !== "") {
+      writer.uint32(26).string(message.p1Group);
+    }
     if (message.p1Idx !== 0) {
-      writer.uint32(24).uint32(message.p1Idx);
+      writer.uint32(32).uint32(message.p1Idx);
     }
     if (message.p2ParentIdx !== 0) {
-      writer.uint32(32).uint32(message.p2ParentIdx);
+      writer.uint32(40).uint32(message.p2ParentIdx);
+    }
+    if (message.p2Group !== "") {
+      writer.uint32(50).string(message.p2Group);
     }
     if (message.p2Idx !== 0) {
-      writer.uint32(40).uint32(message.p2Idx);
+      writer.uint32(56).uint32(message.p2Idx);
     }
     if (message.name !== undefined) {
-      writer.uint32(50).string(message.name);
+      writer.uint32(66).string(message.name);
     }
     if (message.isSelected !== undefined) {
-      writer.uint32(56).bool(message.isSelected);
+      writer.uint32(72).bool(message.isSelected);
     }
     if (message.color !== undefined) {
-      writer.uint32(64).uint32(message.color);
+      writer.uint32(80).uint32(message.color);
     }
     Object.entries(message.otherProps).forEach(([key, value]) => {
-      Wire_OtherPropsEntry.encode({ key: key as any, value }, writer.uint32(74).fork()).join();
+      Wire_OtherPropsEntry.encode({ key: key as any, value }, writer.uint32(90).fork()).join();
     });
     return writer;
   },
@@ -831,11 +840,11 @@ export const Wire: MessageFns<Wire> = {
           continue;
         }
         case 3: {
-          if (tag !== 24) {
+          if (tag !== 26) {
             break;
           }
 
-          message.p1Idx = reader.uint32();
+          message.p1Group = reader.string();
           continue;
         }
         case 4: {
@@ -843,7 +852,7 @@ export const Wire: MessageFns<Wire> = {
             break;
           }
 
-          message.p2ParentIdx = reader.uint32();
+          message.p1Idx = reader.uint32();
           continue;
         }
         case 5: {
@@ -851,7 +860,7 @@ export const Wire: MessageFns<Wire> = {
             break;
           }
 
-          message.p2Idx = reader.uint32();
+          message.p2ParentIdx = reader.uint32();
           continue;
         }
         case 6: {
@@ -859,7 +868,7 @@ export const Wire: MessageFns<Wire> = {
             break;
           }
 
-          message.name = reader.string();
+          message.p2Group = reader.string();
           continue;
         }
         case 7: {
@@ -867,25 +876,41 @@ export const Wire: MessageFns<Wire> = {
             break;
           }
 
-          message.isSelected = reader.bool();
+          message.p2Idx = reader.uint32();
           continue;
         }
         case 8: {
-          if (tag !== 64) {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.isSelected = reader.bool();
+          continue;
+        }
+        case 10: {
+          if (tag !== 80) {
             break;
           }
 
           message.color = reader.uint32();
           continue;
         }
-        case 9: {
-          if (tag !== 74) {
+        case 11: {
+          if (tag !== 90) {
             break;
           }
 
-          const entry9 = Wire_OtherPropsEntry.decode(reader, reader.uint32());
-          if (entry9.value !== undefined) {
-            message.otherProps[entry9.key] = entry9.value;
+          const entry11 = Wire_OtherPropsEntry.decode(reader, reader.uint32());
+          if (entry11.value !== undefined) {
+            message.otherProps[entry11.key] = entry11.value;
           }
           continue;
         }
@@ -902,8 +927,10 @@ export const Wire: MessageFns<Wire> = {
     return {
       kind: isSet(object.kind) ? globalThis.String(object.kind) : undefined,
       p1ParentIdx: isSet(object.p1ParentIdx) ? globalThis.Number(object.p1ParentIdx) : 0,
+      p1Group: isSet(object.p1Group) ? globalThis.String(object.p1Group) : "",
       p1Idx: isSet(object.p1Idx) ? globalThis.Number(object.p1Idx) : 0,
       p2ParentIdx: isSet(object.p2ParentIdx) ? globalThis.Number(object.p2ParentIdx) : 0,
+      p2Group: isSet(object.p2Group) ? globalThis.String(object.p2Group) : "",
       p2Idx: isSet(object.p2Idx) ? globalThis.Number(object.p2Idx) : 0,
       name: isSet(object.name) ? globalThis.String(object.name) : undefined,
       isSelected: isSet(object.isSelected) ? globalThis.Boolean(object.isSelected) : undefined,
@@ -925,11 +952,17 @@ export const Wire: MessageFns<Wire> = {
     if (message.p1ParentIdx !== 0) {
       obj.p1ParentIdx = Math.round(message.p1ParentIdx);
     }
+    if (message.p1Group !== "") {
+      obj.p1Group = message.p1Group;
+    }
     if (message.p1Idx !== 0) {
       obj.p1Idx = Math.round(message.p1Idx);
     }
     if (message.p2ParentIdx !== 0) {
       obj.p2ParentIdx = Math.round(message.p2ParentIdx);
+    }
+    if (message.p2Group !== "") {
+      obj.p2Group = message.p2Group;
     }
     if (message.p2Idx !== 0) {
       obj.p2Idx = Math.round(message.p2Idx);
@@ -962,8 +995,10 @@ export const Wire: MessageFns<Wire> = {
     const message = createBaseWire();
     message.kind = object.kind ?? undefined;
     message.p1ParentIdx = object.p1ParentIdx ?? 0;
+    message.p1Group = object.p1Group ?? "";
     message.p1Idx = object.p1Idx ?? 0;
     message.p2ParentIdx = object.p2ParentIdx ?? 0;
+    message.p2Group = object.p2Group ?? "";
     message.p2Idx = object.p2Idx ?? 0;
     message.name = object.name ?? undefined;
     message.isSelected = object.isSelected ?? undefined;
@@ -1386,13 +1421,13 @@ export const IntegratedCircuitMetadata: MessageFns<IntegratedCircuitMetadata> = 
 };
 
 function createBaseIntegratedCircuitMetadata_Pin(): IntegratedCircuitMetadata_Pin {
-  return { internalCompId: 0, internalPortIdx: 0, group: "", name: "", x: 0, y: 0, dx: 0, dy: 0 };
+  return { internalCompIdx: 0, internalPortIdx: 0, group: "", name: "", x: 0, y: 0, dx: 0, dy: 0 };
 }
 
 export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata_Pin> = {
   encode(message: IntegratedCircuitMetadata_Pin, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.internalCompId !== 0) {
-      writer.uint32(8).uint32(message.internalCompId);
+    if (message.internalCompIdx !== 0) {
+      writer.uint32(8).uint32(message.internalCompIdx);
     }
     if (message.internalPortIdx !== 0) {
       writer.uint32(16).uint32(message.internalPortIdx);
@@ -1430,7 +1465,7 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
             break;
           }
 
-          message.internalCompId = reader.uint32();
+          message.internalCompIdx = reader.uint32();
           continue;
         }
         case 2: {
@@ -1500,7 +1535,7 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
 
   fromJSON(object: any): IntegratedCircuitMetadata_Pin {
     return {
-      internalCompId: isSet(object.internalCompId) ? globalThis.Number(object.internalCompId) : 0,
+      internalCompIdx: isSet(object.internalCompIdx) ? globalThis.Number(object.internalCompIdx) : 0,
       internalPortIdx: isSet(object.internalPortIdx) ? globalThis.Number(object.internalPortIdx) : 0,
       group: isSet(object.group) ? globalThis.String(object.group) : "",
       name: isSet(object.name) ? globalThis.String(object.name) : "",
@@ -1513,8 +1548,8 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
 
   toJSON(message: IntegratedCircuitMetadata_Pin): unknown {
     const obj: any = {};
-    if (message.internalCompId !== 0) {
-      obj.internalCompId = Math.round(message.internalCompId);
+    if (message.internalCompIdx !== 0) {
+      obj.internalCompIdx = Math.round(message.internalCompIdx);
     }
     if (message.internalPortIdx !== 0) {
       obj.internalPortIdx = Math.round(message.internalPortIdx);
@@ -1547,7 +1582,7 @@ export const IntegratedCircuitMetadata_Pin: MessageFns<IntegratedCircuitMetadata
     object: I,
   ): IntegratedCircuitMetadata_Pin {
     const message = createBaseIntegratedCircuitMetadata_Pin();
-    message.internalCompId = object.internalCompId ?? 0;
+    message.internalCompIdx = object.internalCompIdx ?? 0;
     message.internalPortIdx = object.internalPortIdx ?? 0;
     message.group = object.group ?? "";
     message.name = object.name ?? "";

--- a/src/projects/shared/site/src/proto/bridge.ts
+++ b/src/projects/shared/site/src/proto/bridge.ts
@@ -9,14 +9,17 @@ import {MapObj}       from "shared/api/circuit/utils/Functions";
 import {GUID, Schema} from "shared/api/circuit/schema";
 
 import * as ProtoSchema from "./Circuit";
+import {Circuit, Component, IntegratedCircuit, Obj, PortConfig, ReadonlyComponent, ReadonlyWire, Wire} from "shared/api/circuit/public";
+import {V} from "Vector";
+import {BaseObject} from "shared/api/circuit/public/BaseObject";
 
 
-export function SchemaToProto(schema: Schema.Circuit): ProtoSchema.Circuit {
+export function CircuitToProto(circuit: Circuit): ProtoSchema.Circuit {
     function ConvertId(id: GUID): Uint8Array {
         return uuid.parse(id) as Uint8Array;
     }
 
-    function ConvertProps(props: Schema.Obj["props"]): Record<string, ProtoSchema.Prop> {
+    function ConvertProps(props: Record<string, number | string | boolean>): Record<string, ProtoSchema.Prop> {
         return MapObj(props, ([_key, prop]) =>
                     (typeof prop === "boolean"
                         ? { boolVal: prop }
@@ -28,172 +31,266 @@ export function SchemaToProto(schema: Schema.Circuit): ProtoSchema.Circuit {
                         ? { strVal: prop } : {}));
     }
 
-    function ConvertComponent(c: Schema.Component): ProtoSchema.Component {
+    function ConvertComponent(c: ReadonlyComponent): ProtoSchema.Component {
+        const { name, isSelected, x, y, angle, ...otherProps } = c.getProps()
+
+        const matchesPortConfig = (pc: PortConfig) =>
+            Object.entries(pc).every(([group, numPorts]) => c.ports[group]?.length === numPorts);
+
+        const isDefaultPortConfig = matchesPortConfig(c.info.defaultPortConfig);
+        const portConfigIdx = c.info.portConfigs.findIndex(matchesPortConfig);
+
         return {
-            id:    ConvertId(c.id),
-            kind:  c.kind,
-            icId:  (c.icId ? ConvertId(c.icId) : undefined),
-            props: ConvertProps(c.props),
+            kind: (c.isIC() ? "IC" : c.kind),
+
+            icId: (c.isIC() ? ConvertId(c.kind) : undefined),
+
+            portConfigIdx: (isDefaultPortConfig || portConfigIdx === -1 ? undefined : portConfigIdx),
+
+            name:       (name ? name as string : undefined),
+            isSelected: (isSelected ? isSelected as boolean : undefined),
+            x:          (x ? x as number : undefined),
+            y:          (y ? y as number : undefined),
+            angle:      (angle ? angle as number : undefined),
+
+            otherProps:    ConvertProps(otherProps),
+            portOverrides: c.allPorts.map((p) => {
+                const { name, isSelected, ...otherProps } = p.getProps();
+                return ({
+                    group: p.group,
+                    index: p.index,
+
+                    name:       p.name,
+                    isSelected: p.isSelected,
+
+                    otherProps: ConvertProps(otherProps),
+                });
+            }).filter((p) => (p.name || p.isSelected || Object.keys(p.otherProps).length > 0)), // TODODOTOTOTO
         };
     }
 
-    function ConvertWire(w: Schema.Wire): ProtoSchema.Wire {
+    function ConvertWire(w: ReadonlyWire, comps: ReadonlyComponent[]): ProtoSchema.Wire {
+        const { name, isSelected, color, ...otherProps } = w.getProps();
+
         return {
-            id:    ConvertId(w.id),
-            kind:  w.kind,
-            props: ConvertProps(w.props),
-            p1:    ConvertId(w.p1),
-            p2:    ConvertId(w.p2),
+            kind: w.kind,
+
+            p1ParentIdx: comps.findIndex((c) => c.id === w.p1.parent.id),
+            p1Idx:       w.p1.parent.allPorts.findIndex((p) => p.id === w.p1.id),
+
+            p2ParentIdx: comps.findIndex((c) => c.id === w.p2.parent.id),
+            p2Idx:       w.p2.parent.allPorts.findIndex((p) => p.id === w.p2.id),
+
+            name:       (name ? name as string : undefined),
+            isSelected: (isSelected ? isSelected as boolean : undefined),
+            //          Convert color to hex integer
+            color:      (color ? parseInt((color as string).slice(1), 16) : undefined),
+
+            otherProps: ConvertProps(otherProps),
         };
     }
 
-    function ConvertPort(p: Schema.Port): ProtoSchema.Port {
+    function ConvertMetadata(circuit: Circuit | IntegratedCircuit): ProtoSchema.CircuitMetadata {
         return {
-            id:     ConvertId(p.id),
-            kind:   p.kind,
-            props:  ConvertProps(p.props),
-            parent: ConvertId(p.parent),
-            group:  p.group,
-            index:  p.index,
+            id:      ConvertId(circuit.id),
+            name:    circuit.name,
+            desc:    circuit.desc,
+            thumb:   circuit.thumbnail,
+            version: "1.0/0",  // TODO: Update this to use the actual version
         };
     }
 
-    function ConvertObjs(objs: Schema.Obj[]) {
+    function ConvertICMetadata(ic: IntegratedCircuit): ProtoSchema.IntegratedCircuitMetadata {
         return {
-            components: objs
-                .filter((o) => (o.baseKind === "Component"))
-                .map(ConvertComponent),
-            wires: objs
-                .filter((o) => (o.baseKind === "Wire"))
-                .map(ConvertWire),
-            ports: objs
-                .filter((o) => (o.baseKind === "Port"))
-                .map(ConvertPort),
+            metadata: ConvertMetadata(ic),
+
+            displayWidth:  ic.display.size.x,
+            displayHeight: ic.display.size.y,
+
+            pins: ic.display.pins.map((p) => {
+                const compIdx = ic.components.findIndex((c) => (c.allPorts.find((port) => port.id === p.id)));
+                const portIdx = ic.components[compIdx].allPorts.findIndex((port) => port.id === p.id);
+                return ({
+                    internalCompId:  compIdx,
+                    internalPortIdx: portIdx,
+
+                    group: p.group,
+                    name:  p.name,
+
+                    x:  p.pos.x,
+                    y:  p.pos.y,
+                    dx: p.dir.x,
+                    dy: p.dir.y,
+                });
+            }),
         };
     }
 
-    function ConvertMetadata(metadata: Schema.CircuitMetadata): ProtoSchema.CircuitMetadata {
+    function ConvertIC(ic: IntegratedCircuit): ProtoSchema.IntegratedCircuit {
         return {
-            ...metadata,
-            id: ConvertId(metadata.id),
-        };
-    }
-
-    function ConvertICMetadata(metadata: Schema.IntegratedCircuitMetadata): ProtoSchema.IntegratedCircuitMetadata {
-        return {
-            metadata:      ConvertMetadata(metadata),
-            displayWidth:  metadata.displayWidth,
-            displayHeight: metadata.displayHeight,
-            pins:          metadata.pins.map((p) => ({
-                ...p,
-                id: ConvertId(p.id),
-            })),
-        };
-    }
-
-    function ConvertIC(ic: Schema.IntegratedCircuit): ProtoSchema.IntegratedCircuit {
-        return {
-            metadata: ConvertICMetadata(ic.metadata),
-            ...ConvertObjs(ic.objects),
+            metadata:   ConvertICMetadata(ic),
+            components: ic.components.map(ConvertComponent),
+            wires:      ic.wires.map((w) => ConvertWire(w, ic.components)),
         };
     }
 
     return ProtoSchema.Circuit.create({
-        metadata: ConvertMetadata(schema.metadata),
-        camera:   schema.camera,
-        ics:      schema.ics.map(ConvertIC),
-        ...ConvertObjs(schema.objects),
+        metadata:   ConvertMetadata(circuit),
+        // camera:   schema.camera,  TODODOODOD
+        ics:        circuit.getICs().map(ConvertIC),
+        components: circuit.getComponents().map(ConvertComponent),
+        wires:      circuit.getWires().map((w) => ConvertWire(w, circuit.getComponents())),
     });
 }
 
-export function ProtoToSchema(proto: ProtoSchema.Circuit): Schema.Circuit {
+export function ProtoToCircuit<C extends Circuit>(proto: ProtoSchema.Circuit, mainCircuit: C, CreateCircuit: (id: GUID) => C): C {
     function ConvertId(id: Uint8Array): GUID {
         return uuid.stringify(id);
     }
 
-    function ConvertProps(props: Record<string, ProtoSchema.Prop>): Schema.Obj["props"] {
-        return MapObj(props, ([_key, prop]) =>
-                        prop.boolVal ?? prop.floatVal ?? prop.intVal ?? prop.strVal ?? "");
+    function SetProps(obj: BaseObject, props: Record<string, ProtoSchema.Prop>) {
+        for (const [key, prop] of Object.entries(props)) {
+            if (prop.boolVal !== undefined) {
+                obj.setProp(key, prop.boolVal);
+            } else if (prop.intVal !== undefined) {
+                obj.setProp(key, prop.intVal);
+            } else if (prop.floatVal !== undefined) {
+                obj.setProp(key, prop.floatVal);
+            } else if (prop.strVal !== undefined) {
+                obj.setProp(key, prop.strVal);
+            }
+        }
     }
 
-    function ConvertComponent(c: ProtoSchema.Component): Schema.Component {
-        return {
-            baseKind: "Component",
-            ...c,
-            id:       ConvertId(c.id),
-            icId:     c.icId ? ConvertId(c.icId) : undefined,
-            props:    ConvertProps(c.props),
-        };
+    function SetObjects(circuit: Circuit, objs: { components: ProtoSchema.Component[], wires: ProtoSchema.Wire[] }) {
+        const compIdMap = new Map<number, GUID>();
+
+        for (let i = 0; i < objs.components.length; i++) {
+            const c = objs.components[i];
+
+            const comp = circuit.placeComponentAt(c.kind === "IC" ? ConvertId(c.icId!) : c.kind, V(c.x ?? 0, c.y ?? 0));
+
+            compIdMap.set(i, comp.id);
+
+            // Load props
+            comp.name = c.name;
+            comp.isSelected = c.isSelected ?? false;
+            comp.angle = c.angle ?? 0;
+            SetProps(comp, c.otherProps);
+
+            // Load port config and port overrides
+            if (c.portConfigIdx !== undefined)
+                comp.setPortConfig(comp.info.portConfigs[c.portConfigIdx]);
+
+            for (const p of c.portOverrides) {
+                const port = comp.ports[p.group][p.index];
+
+                // Load props
+                port.name = p.name;
+                port.isSelected = p.isSelected ?? false;
+                SetProps(port, p.otherProps);
+            }
+        }
+
+        for (const w of objs.wires) {
+            const p1Parent = circuit.getComponent(compIdMap.get(w.p1ParentIdx)!)!;
+            const p1Port = p1Parent.allPorts[w.p1Idx];
+
+            const p2Parent = circuit.getComponent(compIdMap.get(w.p2ParentIdx)!)!;
+            const p2Port = p2Parent.allPorts[w.p2Idx];
+
+            const wire = p1Port.connectTo(p2Port)!;
+
+            // Load props
+            wire.name = w.name;
+            wire.isSelected = w.isSelected ?? false;
+            if (w.color !== undefined) // Convert color to hex string
+                wire.setProp("color", `#${(w.color & 0xFF_FF_FF).toString(16).padStart(6, "0")}`);
+            SetProps(wire, w.otherProps);
+        }
+
+        return compIdMap;
     }
 
-    function ConvertWire(w: ProtoSchema.Wire): Schema.Wire {
-        return {
-            baseKind: "Wire",
-            ...w,
-            id:       ConvertId(w.id),
-            props:    ConvertProps(w.props),
-            p1:       ConvertId(w.p1),
-            p2:       ConvertId(w.p2),
-        };
+    function SetIC(circuit: Circuit, ic: ProtoSchema.IntegratedCircuit, allICs: Map<GUID, ProtoSchema.IntegratedCircuit>) {
+        const id = ConvertId(ic.metadata!.metadata!.id);
+
+        // If IC already added, skip
+        if (circuit.getIC(id))
+            return;
+
+        // Find IC dependencies and load them first
+        const dependencies = new Set(ic.components.map((c) => c.icId).filter((id) => id !== undefined).map(ConvertId));
+        for (const depId of dependencies)
+            SetIC(circuit, allICs.get(depId)!, allICs);
+
+        // Create the IC circuit
+        const icCircuit = CreateCircuit(id);
+
+        icCircuit.beginTransaction({ batch: true });
+
+        // Import dependencies
+        icCircuit.importICs(circuit.getICs());
+
+        // Load metadata
+        icCircuit.name = ic.metadata!.metadata!.name;
+        icCircuit.desc = ic.metadata!.metadata!.desc;
+        icCircuit.thumbnail = ic.metadata!.metadata!.thumb;
+
+        // Load objects
+        const compIdMap = SetObjects(icCircuit, ic);
+
+        icCircuit.commitTransaction();
+
+        circuit.createIC({
+            circuit: icCircuit,
+            display: {
+                size: V(ic.metadata!.displayWidth, ic.metadata!.displayHeight),
+                pins: ic.metadata!.pins.map((p) => {
+                    // Get internal port ID
+                    const internalComp = icCircuit.getComponent(compIdMap.get(p.internalCompId)!)!;
+                    const port = internalComp.allPorts[p.internalPortIdx];
+
+                    return ({
+                        id:    port.id,
+                        group: p.group,
+                        name:  p.name,
+                        pos:   V(p.x, p.y),
+                        dir:   V(p.dx, p.dy),
+                    });
+                }),
+            },
+        }, id);
     }
 
-    function ConvertPort(p: ProtoSchema.Port): Schema.Port {
-        return {
-            baseKind: "Port",
-            ...p,
-            id:       ConvertId(p.id),
-            props:    ConvertProps(p.props),
-            parent:   ConvertId(p.parent),
-        };
-    }
-
-    function ConvertObjs(components: ProtoSchema.Component[], wires: ProtoSchema.Wire[], ports: ProtoSchema.Port[]): Schema.Obj[] {
-        return [
-            ...components.map(ConvertComponent),
-            ...wires.map(ConvertWire),
-            ...ports.map(ConvertPort),
-        ];
-    }
-
-    function ConvertMetadata(metadata: ProtoSchema.CircuitMetadata): Schema.CircuitMetadata {
-        return {
-            ...metadata,
-            id:      ConvertId(metadata.id),
-            version: metadata.version as `${string}/${string}`,  // TODO[]
-        };
-    }
-
-    function ConvertICMetadata(metadata: ProtoSchema.IntegratedCircuitMetadata): Schema.IntegratedCircuitMetadata {
-        if (!metadata.metadata || !metadata.metadata.id)
-            throw new Error(`ProtoToSchema.ConvertICMetadata: Failed to find metadata! ${metadata}`);
-        return {
-            ...ConvertMetadata(metadata.metadata),
-            id:            ConvertId(metadata.metadata.id),
-            displayWidth:  metadata.displayWidth,
-            displayHeight: metadata.displayHeight,
-            pins:          metadata.pins.map((p) => ({
-                ...p,
-                id: ConvertId(p.id),
-            })),
-        };
-    }
-
-    function ConvertIC(ic: ProtoSchema.IntegratedCircuit): Schema.IntegratedCircuit {
-        if (!ic.metadata)
-            throw new Error(`ProtoToSchema.ConvertIC: Failed to find metadata! ${ic}`);
-        return {
-            metadata: ConvertICMetadata(ic.metadata),
-            objects:  ConvertObjs(ic.components, ic.wires, ic.ports),
-        };
-    }
 
     if (!proto.metadata)
         throw new Error(`ProtoToSchema: Failed to find metadata! ${proto}`);
 
-    return {
-        metadata: ConvertMetadata(proto.metadata),
-        camera:   proto.camera ?? { x: 0, y: 0, zoom: 0.02 },
-        ics:      proto.ics.map(ConvertIC),
-        objects:  ConvertObjs(proto.components, proto.wires, proto.ports),
-    };
+    const circuit = mainCircuit;
+
+    circuit.beginTransaction({ batch: true });
+
+    // Load metadata
+    circuit.name = proto.metadata.name;
+    circuit.desc = proto.metadata.desc;
+    circuit.thumbnail = proto.metadata.thumb;
+
+    // TODODOTOTOTO: Camera
+
+    // Load ICs
+    // This is mildly complicated because we need to load them in order of dependencies.
+    // I.e., if we have IC 1, and IC 2 that contains an instance of IC 1,
+    // we need to load IC 1 first.
+    const icMap = new Map(
+        proto.ics.map((ic) => [ConvertId(ic.metadata!.metadata!.id), ic]));
+    for (const ic of proto.ics)
+        SetIC(circuit, ic, icMap);
+
+    // Load objects
+    SetObjects(circuit, proto);
+
+    circuit.commitTransaction();
+
+    return circuit;
 }

--- a/src/projects/shared/site/src/proto/bridge.ts
+++ b/src/projects/shared/site/src/proto/bridge.ts
@@ -65,7 +65,7 @@ export function CircuitToProto(circuit: Circuit): ProtoSchema.Circuit {
 
                     otherProps: ConvertProps(otherProps),
                 });
-            }).filter((p) => (p.name || p.isSelected || Object.keys(p.otherProps).length > 0)), // TODODOTOTOTO
+            }).filter((p) => (p.name || p.isSelected || Object.keys(p.otherProps).length > 0)),
         };
     }
 
@@ -144,8 +144,12 @@ export function CircuitToProto(circuit: Circuit): ProtoSchema.Circuit {
     const wires = circuit.getWires().sort((w1, w2) => (w1.zIndex, w2.zIndex));
 
     return ProtoSchema.Circuit.create({
-        metadata:   ConvertMetadata(circuit),
-        // camera:   schema.camera,  TODODOODOD
+        metadata: ConvertMetadata(circuit),
+        camera:   {
+            x:    circuit.camera.cx,
+            y:    circuit.camera.cy,
+            zoom: circuit.camera.zoom,
+        },
         ics:        circuit.getICs().map(ConvertIC),
         components: comps.map(ConvertComponent),
         wires:      wires.map((w) => ConvertWire(w, comps)),
@@ -286,7 +290,9 @@ export function ProtoToCircuit<C extends Circuit>(proto: ProtoSchema.Circuit, ma
     circuit.desc = proto.metadata.desc;
     circuit.thumbnail = proto.metadata.thumb;
 
-    // TODODOTOTOTO: Camera
+    circuit.camera.cx = proto.camera?.x ?? 0;
+    circuit.camera.cy = proto.camera?.y ?? 0;
+    circuit.camera.zoom = proto.camera?.zoom ?? 0.02;
 
     // Load ICs
     // This is mildly complicated because we need to load them in order of dependencies.

--- a/src/projects/shared/site/src/utils/CircuitHelpers.ts
+++ b/src/projects/shared/site/src/utils/CircuitHelpers.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {Schema} from "shared/api/circuit/schema";
 import {CircuitDesigner} from "shared/api/circuitdesigner/public/CircuitDesigner";
 import {setCurDesigner} from "./hooks/useDesigner";
 import {ToolConfig} from "shared/api/circuitdesigner/public/impl/CircuitDesigner";
 import {ToolRenderer} from "shared/api/circuitdesigner/tools/renderers/ToolRenderer";
+import {Circuit} from "shared/api/circuit/public";
 
 
 // These are helpers that need to be overridden per-circuit-type (digital, analog, etc.)
@@ -12,8 +12,8 @@ import {ToolRenderer} from "shared/api/circuitdesigner/tools/renderers/ToolRende
 export interface OverrideCircuitHelpers {
     CreateAndInitializeDesigner: (tools?: {config: ToolConfig, renderers?: ToolRenderer[]}) => CircuitDesigner;
 
-    SerializeCircuit: (circuit: Schema.Circuit) => Blob;
-    DeserializeCircuit: (data: string | ArrayBuffer) => Schema.Circuit;
+    SerializeCircuit: (circuit: Circuit) => Blob;
+    DeserializeCircuit: (data: string | ArrayBuffer) => Circuit;
 }
 
 // These are helpers that can be defined in a shared context and apply to all types.
@@ -62,9 +62,9 @@ export const CircuitHelpers: CircuitHelpers = {
 
     LoadNewCircuit(data) {
         // Create new circuit to override old one
-        const schema = CircuitHelpers.DeserializeCircuit(data);
+        const circuit = CircuitHelpers.DeserializeCircuit(data);
         const newDesigner = CircuitHelpers.CreateAndInitializeDesigner();
-        newDesigner.circuit.loadSchema(schema, { loadMetadata: true });
+        newDesigner.circuit.import(circuit, { loadMetadata: true });
         newDesigner.circuit.history.clear();
         setCurDesigner(newDesigner);
 


### PR DESCRIPTION
Initial PR to add a way to avoid using the interal Schema rep and completely changed the wire rep to be as space-efficient as possible.

- Made the IC API object queryable for its contents
- Added better API 'readonly' support