### PR TITLE
Add back replace component dropdown

### DIFF
--- a/src/projects/digital/site/src/containers/SelectionPopup/modules/ReplaceComponentDropdownModule.tsx
+++ b/src/projects/digital/site/src/containers/SelectionPopup/modules/ReplaceComponentDropdownModule.tsx
@@ -30,7 +30,6 @@ type Props = {
     circuit: Circuit;
 }
 export const ReplaceComponentDropdownModule = ({ circuit }: Props) => {
-    // TODO[model_refactor_api]
     const [props] = useSelectionProps(
         circuit,
         (c): c is DigitalComponent => (c.baseKind === "Component"),

--- a/src/projects/digital/site/src/containers/SelectionPopup/modules/ReplaceComponentDropdownModule.tsx
+++ b/src/projects/digital/site/src/containers/SelectionPopup/modules/ReplaceComponentDropdownModule.tsx
@@ -29,7 +29,6 @@ const swappableComponents = [
 type Props = {
     circuit: Circuit;
 }
-// eslint-disable-next-line arrow-body-style
 export const ReplaceComponentDropdownModule = ({ circuit }: Props) => {
     // TODO[model_refactor_api]
     const [props] = useSelectionProps(


### PR DESCRIPTION
Closes #1441 

Much simpler than the previous implementation (since the previous one is still nightly only). Adding ICs into the mix would be a good future thing to work on (post model refactor merge to master), especially since now ICs must be named.