### PR TITLE
Security: Potential Prototype Pollution in mergeDeep Utility

### DIFF
--- a/scripts/utils/merge.ts
+++ b/scripts/utils/merge.ts
@@ -13,6 +13,8 @@ export default function mergeDeep(...objects: object[]): object {
 
     return objects.reduce((prev, obj) => {
         Object.keys(obj).forEach((key) => {
+            if (key === "__proto__" || key === "constructor" || key === "prototype")
+                return;
             const pVal = prev[key];
             const oVal = obj[key];
 


### PR DESCRIPTION
## Summary

Security: Potential Prototype Pollution in mergeDeep Utility

## Problem

**Severity**: `High` | **File**: `scripts/utils/merge.ts:L10`

The `mergeDeep` function in `scripts/utils/merge.ts` recursively merges objects without checking for prototype pollution via `__proto__`, `constructor`, or `prototype` keys. An attacker with control over the input objects could potentially pollute the prototype chain of the returned object or global Object prototype, leading to remote code execution or property injection attacks.

## Solution

Add checks to skip `__proto__`, `constructor`, and `prototype` keys during merge operations. Use `Object.hasOwn` or check with `obj.hasOwnProperty(key)` before assigning properties. Consider using a well-tested library like `lodash.merge` or `deepmerge` instead.

## Changes

- `scripts/utils/merge.ts` (modified)